### PR TITLE
Add shorthand for all patient and appt functions

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -85,11 +85,12 @@ Shows a message explaning how to access the help page.
 Format: `help`
 
 
-### Adding a patient: `addPatient`
+### Adding a patient: `addPatient` OR `ap`
 
 Adds a patient to CLInic.
 
-Format: `addPatient n/NAME i/NRIC b/DOB p/PHONE_NUMBER e/EMAIL a/ADDRESS [t/TAG]…​`
+Format: `addPatient n/NAME i/NRIC b/DOB p/PHONE_NUMBER e/EMAIL a/ADDRESS [t/TAG]…​` <br/>
+Shorthand: `ap n/NAME i/NRIC b/DOB p/PHONE_NUMBER e/EMAIL a/ADDRESS [t/TAG]…​`
 
 <box type="tip" seamless>
 
@@ -99,13 +100,15 @@ Format: `addPatient n/NAME i/NRIC b/DOB p/PHONE_NUMBER e/EMAIL a/ADDRESS [t/TAG]
 Examples:
 * `addPatient n/John Doe i/T0123456A b/2001-05-02 p/98765432 e/johnd@example.com a/John street, block 123, #01-01`
 * `addPatient n/Betsy Crowe i/S1234567A b/2001-02-03 t/friend e/betsycrowe@example.com a/Newgate Prison p/1234567 t/criminal`
+* `ap n/Betsy Crowe i/S1234567A b/2001-02-03 t/friend e/betsycrowe@example.com a/Newgate Prison p/1234567 t/criminal`
 
-### Deleting a patient : `deletePatient`
+### Deleting a patient : `deletePatient` OR `dp`
 
 Deletes the specified patient (identified by NRIC) from CLInic.
 Corresponding appointments for the specified patient will be deleted too.
 
-Format: `deletePatient NRIC`
+Format: `deletePatient NRIC` <br/>
+Shorthand: `dp NRIC`
 
 * Deletes the patient with specified `NRIC`.
 * The NRIC **must exist within database**.
@@ -113,11 +116,12 @@ Format: `deletePatient NRIC`
 Examples:
 * `deletePatient S1234567A` deletes the patient with NRIC S1234567A in CLInic.
 
-### Editing a patient : `editPatient`
+### Editing a patient : `editPatient` OR `ep`
 
 Edits an existing patient in CLInic.
 
-Format: `editPatient NRIC [b/DOB] [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [t/TAG]…​`
+Format: `editPatient NRIC [b/DOB] [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [t/TAG]…​` <br/>
+Shorthand: `ep NRIC [b/DOB] [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [t/TAG]…​`
 
 * Edits the patient with the specified NRIC.
 * Ensure the NRIC is valid and exists in the system.
@@ -128,12 +132,14 @@ Format: `editPatient NRIC [b/DOB] [n/NAME] [p/PHONE] [e/EMAIL] [a/ADDRESS] [t/TA
 Examples:
 *  `editPatient T0123456A p/91234567 e/johndoe@example.com` Edits the phone number and email address of the patient with NRIC:`T0123456A` to be `91234567` and `johndoe@example.com` respectively.
 *  `editPatient S8765432Z n/Betsy Crower t/` Edits the name of the patient with NRIC:`S8765432Z` to be `Betsy Crower` and clears all existing tags.
+*  `ep S8765432Z n/Betsy Crower t/`
 
-### Locating patients: `findPatient`
+### Locating patients: `findPatient` OR `fp`
 
 Finds patients whose name OR NRIC fit the given keywords.
 
-Format: `findPatient n/ KEYWORD [MORE_KEYWORDS]` OR `findPatient i/ KEYWORD`
+Format: `findPatient n/ KEYWORD [MORE_KEYWORDS]` OR `findPatient i/ KEYWORD` <br/>
+Shorthand: `fp n/ KEYWORD [MORE_KEYWORDS]` OR `fp i/ KEYWORD`
 
 * The search is case-insensitive. e.g `hans` will match `Hans`
 * The order of the keywords does not matter. e.g. `Hans Bo` will match `Bo Hans`
@@ -149,6 +155,7 @@ Examples:
 * `findPatient i/ S9` returns patients with NRICs `S9876543A` and `S9765432A`
 * `findPatient n/ John` returns patients with names `john` and `John Doe`
 * `findPatient n/ alex david` returns patients with names `Alex Yeoh`, `David Li`<br>
+* `fp n/ alex david` returns patients with names `Alex Yeoh`, `David Li`<br>
   ![result for 'find alex david'](images/findAlexDavidResult.png)
 
 ### Listing all patients : `list`
@@ -157,11 +164,12 @@ Shows a list of all patients in CLInic.
 
 Format: `list`
 
-### Adding an Appointment: `addAppt`
+### Adding an Appointment: `addAppt` OR `aa`
 
 Adds an appointment to the CLInic.
 
-Format: `addAppt i/NRIC d/DATE from/START_TIME to/END_TIME t/APPOINTMENT_TYPE [note/NOTE]`
+Format: `addAppt i/NRIC d/DATE from/START_TIME to/END_TIME t/APPOINTMENT_TYPE [note/NOTE]` <br/>
+Shorthand: `aa i/NRIC d/DATE from/START_TIME to/END_TIME t/APPOINTMENT_TYPE [note/NOTE]`
 
 * Adds an appointment for the patient with specified `NRIC`, on `DATE` from `START_TIME` to `END_TIME`
 * Patient with this NRIC **must exist within database**.
@@ -171,24 +179,28 @@ Format: `addAppt i/NRIC d/DATE from/START_TIME to/END_TIME t/APPOINTMENT_TYPE [n
 Examples:
 * `addAppt i/ T0123456A d/ 2024-02-20 from/ 11:00 to/ 11:30 t/ Medical Check-up note/ Routine check-in`
 * `addAppt i/ S1234567A d/ 2024-02-20 from/ 15:00 to/ 15:30 t/ Blood Test note/ Follow-up from last consultation`
+* `aa i/ S1234567A d/ 2024-02-20 from/ 15:00 to/ 15:30 t/ Blood Test note/ Follow-up from last consultation`
 
-### Deleting an Appointment: `deleteAppt`
+### Deleting an Appointment: `deleteAppt` OR `da`
 
 Deleting an appointment from CLInic.
 
-Format: `deleteAppt i/NRIC d/DATE from/START_TIME to/END_TIME`
+Format: `deleteAppt i/NRIC d/DATE from/START_TIME to/END_TIME` <br/>
+Shorthand: `da i/NRIC d/DATE from/START_TIME to/END_TIME`
 
 * Deletes an appointment for the patient with specified `NRIC`, on `DATE` from `START_TIME` to `END_TIME`
 * Appointment with the following details **must exist within database**.
 
 Examples:
 * `deleteAppt i/ S8743880A d/ 2024-02-20 from/ 11:00 to/ 11:30`
+* `da i/ S8743880A d/ 2024-02-20 from/ 11:00 to/ 11:30`
 
-### Finding appointments: `findAppt`
+### Finding appointments: `findAppt` OR `fa`
 
 Finds appointments based on the given parameters.
 
 Format: `findAppt [i/NRIC] [d/DATE] [from/START_TIME]`
+Shorthand: `fa [i/NRIC] [d/DATE] [from/START_TIME]`
 
 * Filters an appointment with specific `NRIC`, `DATE` or `START_TIME` (any combination of the 3)
 * If invalid parameters, error detailing what went wrong will be displayed.
@@ -197,6 +209,7 @@ Format: `findAppt [i/NRIC] [d/DATE] [from/START_TIME]`
 
 Examples:
 * `findAppt d/ 2024-02-20 from/ 11:00`
+* `fa d/ 2024-02-20 from/ 11:00`
 *  returns you all appointments on `2024-02-20` starting from `11:00` and later. 
 
 ### Clearing all entries : `clear`

--- a/src/main/java/seedu/address/logic/commands/AddAppCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddAppCommand.java
@@ -23,6 +23,8 @@ public class AddAppCommand extends Command {
 
     public static final String COMMAND_WORD = "addApp";
 
+    public static final String COMMAND_WORD_ALT = "aa";
+
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Adds an appointment for the patient identified by the NRIC given. \n"
             + "Parameters: "

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -22,6 +22,8 @@ public class AddCommand extends Command {
 
     public static final String COMMAND_WORD = "add";
 
+    public static final String COMMAND_WORD_ALT = "ap";
+
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a patient to the CLInic. "
             + "Parameters: "
             + PREFIX_NAME + "NAME "

--- a/src/main/java/seedu/address/logic/commands/CancelAppCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CancelAppCommand.java
@@ -24,6 +24,8 @@ public class CancelAppCommand extends Command {
 
     public static final String COMMAND_WORD = "cancelApp";
 
+    public static final String COMMAND_WORD_ALT = "ca";
+
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Cancels the appointment identified by the NRIC, date, start time and end time given.\n"
             + "Parameters: "

--- a/src/main/java/seedu/address/logic/commands/CancelAppCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CancelAppCommand.java
@@ -24,7 +24,7 @@ public class CancelAppCommand extends Command {
 
     public static final String COMMAND_WORD = "cancelApp";
 
-    public static final String COMMAND_WORD_ALT = "ca";
+    public static final String COMMAND_WORD_ALT = "da";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Cancels the appointment identified by the NRIC, date, start time and end time given.\n"

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -15,6 +15,8 @@ public class DeleteCommand extends Command {
 
     public static final String COMMAND_WORD = "delete";
 
+    public static final String COMMAND_WORD_ALT = "dp";
+
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Deletes the person identified by the NRIC number used in the displayed person list.\n"
             + "Parameters: NRIC (must be a existing NRIC in database)\n"

--- a/src/main/java/seedu/address/logic/commands/EditPersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditPersonCommand.java
@@ -36,6 +36,8 @@ public class EditPersonCommand extends Command {
 
     public static final String COMMAND_WORD = "editPerson";
 
+    public static final String COMMAND_WORD_ALT = "ep";
+
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Edits the details of the person identified by their Nric number. "
             + "Existing values will be overwritten by the input values.\n"

--- a/src/main/java/seedu/address/logic/commands/FindApptCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindApptCommand.java
@@ -18,6 +18,8 @@ public class FindApptCommand extends Command {
 
     public static final String COMMAND_WORD = "findAppt";
 
+    public static final String COMMAND_WORD_ALT = "fa";
+
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Finds the details of the appointment identified either by patient's NRIC, Date, or Start time.\n"
             + "Parameters: "

--- a/src/main/java/seedu/address/logic/commands/FindPersonCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindPersonCommand.java
@@ -19,6 +19,8 @@ public class FindPersonCommand extends Command {
 
     public static final String COMMAND_WORD = "findPerson";
 
+    public static final String COMMAND_WORD_ALT = "fp";
+
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Finds all persons whose names OR nric start with "
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -57,21 +57,26 @@ public class AddressBookParser {
         switch (commandWord) {
 
         case AddCommand.COMMAND_WORD:
+        case AddCommand.COMMAND_WORD_ALT:
             return new AddCommandParser().parse(arguments);
 
         case EditPersonCommand.COMMAND_WORD:
+        case EditPersonCommand.COMMAND_WORD_ALT:
             return new EditPersonCommandParser().parse(arguments);
 
         case DeleteCommand.COMMAND_WORD:
+        case DeleteCommand.COMMAND_WORD_ALT:
             return new DeleteCommandParser().parse(arguments);
 
         case ClearCommand.COMMAND_WORD:
             return new ClearCommand();
 
         case FindApptCommand.COMMAND_WORD:
+        case FindApptCommand.COMMAND_WORD_ALT:
             return new FindApptCommandParser().parse(arguments);
 
         case FindPersonCommand.COMMAND_WORD:
+        case FindPersonCommand.COMMAND_WORD_ALT:
             return new FindPersonCommandParser().parse(arguments);
 
         case ListCommand.COMMAND_WORD:
@@ -84,9 +89,11 @@ public class AddressBookParser {
             return new HelpCommand();
 
         case AddAppCommand.COMMAND_WORD:
+        case AddAppCommand.COMMAND_WORD_ALT:
             return new AddAppCommandParser().parse(arguments);
 
         case CancelAppCommand.COMMAND_WORD:
+        case CancelAppCommand.COMMAND_WORD_ALT:
             return new CancelAppCommandParser().parse(arguments);
 
         default:


### PR DESCRIPTION
Have yet to update the commands to fit new form.

e.g. `delete `is yet to be updated to `deletePatient`, but `dp` is shorthand notation.
All commands in AddressBookParser yet to be updated for cases.

e.g. currently still

`case AddCommand.COMMAND_WORD:`
`case AddCommand.COMMAND_WORD_ALT:`
`      return new AddCommandParser().parse(arguments);`