### PR TITLE
Add EditApptCommand

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -196,6 +196,25 @@ Examples:
 * `deleteAppt i/ S8743880A d/ 2024-02-20 from/ 11:00 to/ 11:30`
 * `da i/ S8743880A d/ 2024-02-20 from/ 11:00 to/ 11:30`
 
+### Editing an Appointment : `editAppointment` OR `ea`
+
+Edits an existing appointment in CLInic.
+
+Format: `editAppt i/NRIC d/DATE from/START_TIME to/END_TIME [newd/DATE] [newfrom/START_TIME] [newto/END_TIME] [newt/APPOINTMENT_TYPE] [newnote/NOTE]` <br/>
+Shorthand: `ea i/NRIC d/DATE from/START_TIME to/END_TIME [newd/DATE] [newfrom/START_TIME] [newto/END_TIME] [newt/APPOINTMENT_TYPE] [newnote/NOTE]`
+
+* Edits the appointment with the specified NRIC, DATE, START_TIME and END_TIME.
+* Ensure the NRIC is valid and exists in the system.
+* Provide at least one optional field for editing.
+* Existing values will be updated to the input values.
+
+Examples:
+*  `editAppt i/T0123456A d/2024-02-20 from/11:00 to/11:30 newd/2024-02-21` 
+  * Edits the date of the appointment with NRIC:`T0123456A`, DATE: `2024-02-20`, START_TIME: `11:00`, END_TIME: `11:30` to be `2024-02-21` instead.
+*  `editAppt i/S8743880A d/2024-10-20 from/14:00 to/16:30 newnote/` 
+  * Clears note for appointment with NRIC:`S8743880A`, DATE: `2024-10-20`, START_TIME: `14:00`, END_TIME: `16:30`.
+*  `ea i/S8743880A d/2024-10-20 from/14:00 to/16:30 newnote/`
+
 ### Finding appointments: `findAppt` OR `fa`
 
 Finds appointments based on the given parameters.
@@ -309,18 +328,19 @@ _Details coming soon ..._
 --------------------------------------------------------------------------------------------------------------------
 
 ## Command summary
-| Action            | Format, Examples                                                                                                                                                                                 |
-|-------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **AddPatient**    | `addPatient n/NAME i/NRIC b/DOB p/PHONE_NUMBER e/EMAIL a/ADDRESS [t/TAG]…​` <br> e.g., `add n/John Doe i/T0123456A b/2001-05-02 p/98765432 e/johnd@example.com a/John street, block 123, #01-01` |
-| **DeletePatient** | `deletePatient NRIC`<br> e.g., `delete T0123456A`                                                                                                                                                |                                                                 |
-| **EditPatient**   | `editPatient NRIC [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [t/TAG]…​`<br> e.g.,`editPatient T0123456A n/James Lee e/jameslee@example.com`                                                 |
-| **FindPatient**   | `findPatient n/ KEYWORD [MORE_KEYWORDS]` OR `findPatient i/ KEYWORD`<br> e.g., `findPatient n/ James Jake`                                                                                       |
-| **List**          | `list`                                                                                                                                                                                           |
-| **AddAppt**       | `addAppt i/NRIC d/DATE from/START_TIME to/END_TIME t/APPOINTMENT_TYPE note/NOTE`<br> e.g., `addAppt i/ T0123456A d/ 2024-02-20 from/ 11:00 to/ 11:30 t/ Medical Check-up note/ Routine check-in` |
-| **DeleteAppt**    | `deleteAppt i/NRIC d/DATE from/START_TIME to/END_TIME` <br> e.g., `deleteAppt i/ S8743880A d/ 2024-02-20 from/ 11:00 to/ 11:30`                                                                  |
-| **FindAppt**      | `findAppt [i/NRIC] [d/DATE] [from/START_TIME]` <br> e.g., `findAppt i/ T0123456A d/ 2024-02-20 from/ 11:00`                                                                                      |
-| **Mark**      | `mark i/NRIC d/DATE from/START_TIME to/END_TIME` <br> e.g., `mark i/ T0123456A d/ 2024-02-20 from/ 11:00 to/ 11:30`                                                                                      |
-| **Unmark**      | `unmark i/NRIC d/DATE from/START_TIME to/END_TIME` <br> e.g., `unmark i/ T0123456A d/ 2024-02-20 from/ 11:00 to/ 11:30`                                                                                      |
-| **Clear**         | `clear`                                                                                                                                                                                          |
-| **Exit**          | `exit`                                                                                                                                                                                           |
-| **Help**          | `help`                                                                                                                                                                                           |
+| Action            | Format, Examples                                                                                                                                                                                                                 |
+|-------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **AddPatient**    | `addPatient n/NAME i/NRIC b/DOB p/PHONE_NUMBER e/EMAIL a/ADDRESS [t/TAG]…​` <br> e.g., `add n/John Doe i/T0123456A b/2001-05-02 p/98765432 e/johnd@example.com a/John street, block 123, #01-01`                                 |
+| **DeletePatient** | `deletePatient NRIC`<br> e.g., `delete T0123456A`                                                                                                                                                                                |                                                                 |
+| **EditPatient**   | `editPatient NRIC [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [t/TAG]…​`<br> e.g.,`editPatient T0123456A n/James Lee e/jameslee@example.com`                                                                                 |
+| **FindPatient**   | `findPatient n/ KEYWORD [MORE_KEYWORDS]` OR `findPatient i/ KEYWORD`<br> e.g., `findPatient n/ James Jake`                                                                                                                       |
+| **List**          | `list`                                                                                                                                                                                                                           |
+| **AddAppt**       | `addAppt i/NRIC d/DATE from/START_TIME to/END_TIME t/APPOINTMENT_TYPE note/NOTE`<br> e.g., `addAppt i/ T0123456A d/ 2024-02-20 from/ 11:00 to/ 11:30 t/ Medical Check-up note/ Routine check-in`                                 |
+| **DeleteAppt**    | `deleteAppt i/NRIC d/DATE from/START_TIME to/END_TIME` <br> e.g., `deleteAppt i/ S8743880A d/ 2024-02-20 from/ 11:00 to/ 11:30`                                                                                                  |
+| **EditAppt**      | `editAppt i/NRIC d/DATE from/START_TIME to/END_TIME [newd/DATE] [newfrom/START_TIME] [newto/END_TIME] [newt/APPOINTMENT_TYPE] [newnote/NOTE]` <br> e.g., `editAppt i/T0123456A d/2024-02-20 from/11:00 to/11:30 newd/2024-02-21` |
+| **FindAppt**      | `findAppt [i/NRIC] [d/DATE] [from/START_TIME]` <br> e.g., `findAppt i/ T0123456A d/ 2024-02-20 from/ 11:00`                                                                                                                      |
+| **Mark**          | `mark i/NRIC d/DATE from/START_TIME to/END_TIME` <br> e.g., `mark i/ T0123456A d/ 2024-02-20 from/ 11:00 to/ 11:30`                                                                                                              |
+| **Unmark**        | `unmark i/NRIC d/DATE from/START_TIME to/END_TIME` <br> e.g., `unmark i/ T0123456A d/ 2024-02-20 from/ 11:00 to/ 11:30`                                                                                                          |
+| **Clear**         | `clear`                                                                                                                                                                                                                          |
+| **Exit**          | `exit`                                                                                                                                                                                                                           |
+| **Help**          | `help`                                                                                                                                                                                                                           |

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -209,11 +209,11 @@ Shorthand: `ea i/NRIC d/DATE from/START_TIME to/END_TIME [newd/DATE] [newfrom/ST
 * Existing values will be updated to the input values.
 
 Examples:
-*  `editAppt i/T0123456A d/2024-02-20 from/11:00 to/11:30 newd/2024-02-21` 
+*  `editAppt i/ T0123456A d/ 2024-02-20 from/ 11:00 to/ 11:30 newd/ 2024-02-21` 
   * Edits the date of the appointment with NRIC:`T0123456A`, DATE: `2024-02-20`, START_TIME: `11:00`, END_TIME: `11:30` to be `2024-02-21` instead.
-*  `editAppt i/S8743880A d/2024-10-20 from/14:00 to/16:30 newnote/` 
+*  `editAppt i/ S8743880A d/ 2024-10-20 from/ 14:00 to/ 16:30 newnote/ ` 
   * Clears note for appointment with NRIC:`S8743880A`, DATE: `2024-10-20`, START_TIME: `14:00`, END_TIME: `16:30`.
-*  `ea i/S8743880A d/2024-10-20 from/14:00 to/16:30 newnote/`
+*  `ea i/ S8743880A d/ 2024-10-20 from/ 14:00 to/ 16:30 newnote/ `
 
 ### Finding appointments: `findAppt` OR `fa`
 
@@ -244,25 +244,13 @@ Format: `mark i/ NRIC d/ DATE /from START_TIME /to END_TIME`
 Examples:
 * `mark i/ T0123456A d/ 2024-02-20 from/ 11:00 to/ 11:30`
 
-### Marking an Appointment: `mark`
-
-Marks an appointment from the address book.
-
-Format: `mark i/ NRIC d/ DATE /from START_TIME /to END_TIME`
-
-* Marks an appointment for the person with specified `NRIC`, on `DATE` from `START_TIME` to `END_TIME`
-* Appointment with the following details **must exist within database**.
-
-Examples:
-* `mark i/ T0123456A d/ 2024-02-20 from/ 11:00 to/ 11:30`
-
 ### Unmarking an Appointment: `unmark`
 
 Unmarks an appointment from the address book.
 
 Format: `unmark i/ NRIC d/ DATE /from START_TIME /to END_TIME`
 
-* Unmarks an appointment for the person with specified `NRIC`, on `DATE` from `START_TIME` to `END_TIME`
+* Unmarks an appointment for the patient with specified `NRIC`, on `DATE` from `START_TIME` to `END_TIME`
 * Appointment with the following details **must exist within database**.
 
 Examples:
@@ -328,19 +316,19 @@ _Details coming soon ..._
 --------------------------------------------------------------------------------------------------------------------
 
 ## Command summary
-| Action            | Format, Examples                                                                                                                                                                                                                 |
-|-------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **AddPatient**    | `addPatient n/NAME i/NRIC b/DOB p/PHONE_NUMBER e/EMAIL a/ADDRESS [t/TAG]…​` <br> e.g., `add n/John Doe i/T0123456A b/2001-05-02 p/98765432 e/johnd@example.com a/John street, block 123, #01-01`                                 |
-| **DeletePatient** | `deletePatient NRIC`<br> e.g., `delete T0123456A`                                                                                                                                                                                |                                                                 |
-| **EditPatient**   | `editPatient NRIC [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [t/TAG]…​`<br> e.g.,`editPatient T0123456A n/James Lee e/jameslee@example.com`                                                                                 |
-| **FindPatient**   | `findPatient n/ KEYWORD [MORE_KEYWORDS]` OR `findPatient i/ KEYWORD`<br> e.g., `findPatient n/ James Jake`                                                                                                                       |
-| **List**          | `list`                                                                                                                                                                                                                           |
-| **AddAppt**       | `addAppt i/NRIC d/DATE from/START_TIME to/END_TIME t/APPOINTMENT_TYPE note/NOTE`<br> e.g., `addAppt i/ T0123456A d/ 2024-02-20 from/ 11:00 to/ 11:30 t/ Medical Check-up note/ Routine check-in`                                 |
-| **DeleteAppt**    | `deleteAppt i/NRIC d/DATE from/START_TIME to/END_TIME` <br> e.g., `deleteAppt i/ S8743880A d/ 2024-02-20 from/ 11:00 to/ 11:30`                                                                                                  |
-| **EditAppt**      | `editAppt i/NRIC d/DATE from/START_TIME to/END_TIME [newd/DATE] [newfrom/START_TIME] [newto/END_TIME] [newt/APPOINTMENT_TYPE] [newnote/NOTE]` <br> e.g., `editAppt i/T0123456A d/2024-02-20 from/11:00 to/11:30 newd/2024-02-21` |
-| **FindAppt**      | `findAppt [i/NRIC] [d/DATE] [from/START_TIME]` <br> e.g., `findAppt i/ T0123456A d/ 2024-02-20 from/ 11:00`                                                                                                                      |
-| **Mark**          | `mark i/NRIC d/DATE from/START_TIME to/END_TIME` <br> e.g., `mark i/ T0123456A d/ 2024-02-20 from/ 11:00 to/ 11:30`                                                                                                              |
-| **Unmark**        | `unmark i/NRIC d/DATE from/START_TIME to/END_TIME` <br> e.g., `unmark i/ T0123456A d/ 2024-02-20 from/ 11:00 to/ 11:30`                                                                                                          |
-| **Clear**         | `clear`                                                                                                                                                                                                                          |
-| **Exit**          | `exit`                                                                                                                                                                                                                           |
-| **Help**          | `help`                                                                                                                                                                                                                           |
+| Action            | Format, Examples                                                                                                                                                                                                                      |
+|-------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **AddPatient**    | `addPatient n/NAME i/NRIC b/DOB p/PHONE_NUMBER e/EMAIL a/ADDRESS [t/TAG]…​` <br> e.g., `add n/John Doe i/T0123456A b/2001-05-02 p/98765432 e/johnd@example.com a/John street, block 123, #01-01`                                      |
+| **DeletePatient** | `deletePatient NRIC`<br> e.g., `delete T0123456A`                                                                                                                                                                                     |                                                                 |
+| **EditPatient**   | `editPatient NRIC [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [a/ADDRESS] [t/TAG]…​`<br> e.g.,`editPatient T0123456A n/James Lee e/jameslee@example.com`                                                                                      |
+| **FindPatient**   | `findPatient n/ KEYWORD [MORE_KEYWORDS]` OR `findPatient i/ KEYWORD`<br> e.g., `findPatient n/ James Jake`                                                                                                                            |
+| **List**          | `list`                                                                                                                                                                                                                                |
+| **AddAppt**       | `addAppt i/NRIC d/DATE from/START_TIME to/END_TIME t/APPOINTMENT_TYPE note/NOTE`<br> e.g., `addAppt i/ T0123456A d/ 2024-02-20 from/ 11:00 to/ 11:30 t/ Medical Check-up note/ Routine check-in`                                      |
+| **DeleteAppt**    | `deleteAppt i/NRIC d/DATE from/START_TIME to/END_TIME` <br> e.g., `deleteAppt i/ S8743880A d/ 2024-02-20 from/ 11:00 to/ 11:30`                                                                                                       |
+| **EditAppt**      | `editAppt i/NRIC d/DATE from/START_TIME to/END_TIME [newd/DATE] [newfrom/START_TIME] [newto/END_TIME] [newt/APPOINTMENT_TYPE] [newnote/NOTE]` <br> e.g., `editAppt i/ T0123456A d/ 2024-02-20 from/ 11:00 to/ 11:30 newd/ 2024-02-21` |
+| **FindAppt**      | `findAppt [i/NRIC] [d/DATE] [from/START_TIME]` <br> e.g., `findAppt i/ T0123456A d/ 2024-02-20 from/ 11:00`                                                                                                                           |
+| **Mark**          | `mark i/NRIC d/DATE from/START_TIME to/END_TIME` <br> e.g., `mark i/ T0123456A d/ 2024-02-20 from/ 11:00 to/ 11:30`                                                                                                                   |
+| **Unmark**        | `unmark i/NRIC d/DATE from/START_TIME to/END_TIME` <br> e.g., `unmark i/ T0123456A d/ 2024-02-20 from/ 11:00 to/ 11:30`                                                                                                               |
+| **Clear**         | `clear`                                                                                                                                                                                                                               |
+| **Exit**          | `exit`                                                                                                                                                                                                                                |
+| **Help**          | `help`                                                                                                                                                                                                                                |

--- a/src/main/java/seedu/address/logic/commands/EditApptCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditApptCommand.java
@@ -69,7 +69,7 @@ public class EditApptCommand extends Command {
     private final EditApptDescriptor editApptDescriptor;
 
     /**
-     * @param nric of the appointment to
+     * @param nric of the appointment for edit
      * @param date of the appointment to edit
      * @param timePeriod of the appointment to edit
      * @param editApptDescriptor details to edit the appointment with

--- a/src/main/java/seedu/address/logic/commands/EditApptCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditApptCommand.java
@@ -1,0 +1,244 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_END_TIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NEW_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NEW_END_TIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NEW_NOTE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NEW_START_TIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NEW_TAG;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_START_TIME;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_APPOINTMENT_VIEWS;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import seedu.address.commons.core.date.Date;
+import seedu.address.commons.util.CollectionUtil;
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.appointment.Appointment;
+import seedu.address.model.appointment.AppointmentType;
+import seedu.address.model.appointment.Mark;
+import seedu.address.model.appointment.Note;
+import seedu.address.model.appointment.TimePeriod;
+import seedu.address.model.patient.Nric;
+
+/**
+ * Edits the details of an existing appointment in CLInic.
+ */
+public class EditApptCommand extends Command {
+
+    public static final String COMMAND_WORD = "editAppt";
+
+    public static final String COMMAND_WORD_ALT = "ea";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Edits the details of the appointment identified by its Nric, Date, End and Start time.\n"
+            + "Existing values will be overwritten by the input values.\n"
+            + "Parameters: "
+            + PREFIX_NRIC + "NRIC (must be a valid NRIC in the system) "
+            + PREFIX_DATE + "DATE "
+            + PREFIX_START_TIME + "START_TIME "
+            + PREFIX_END_TIME + "END_TIME "
+            + "[" + PREFIX_NEW_DATE + "new DATE] "
+            + "[" + PREFIX_NEW_START_TIME + "new START_TIME] "
+            + "[" + PREFIX_NEW_END_TIME + "new END_TIME] "
+            + "[" + PREFIX_NEW_TAG + "new APPOINTMENT_TYPE] "
+            + "[" + PREFIX_NEW_NOTE + "new NOTE] \n"
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_NRIC + "T0123456A "
+            + PREFIX_DATE + "2024-02-20 "
+            + PREFIX_START_TIME + "11:00 "
+            + PREFIX_END_TIME + "11:30 "
+            + PREFIX_NEW_END_TIME + "12:30 "
+            + PREFIX_NEW_TAG + "Blood test "
+            + PREFIX_NEW_NOTE + "May come later ";
+
+    public static final String MESSAGE_EDIT_APPT_SUCCESS = "Edited Appointment: %1$s";
+    public static final String MESSAGE_EDIT_APPT_NO_FIELDS_FAILURE = "At least one field to edit must be provided.";
+
+    private final Nric targetNric;
+    private final Date targetDate;
+    private final TimePeriod targetTimePeriod;
+    private Appointment apptToEdit;
+    private final EditApptDescriptor editApptDescriptor;
+
+    /**
+     * @param nric of the appointment to
+     * @param date of the appointment to edit
+     * @param timePeriod of the appointment to edit
+     * @param editApptDescriptor details to edit the appointment with
+     */
+    public EditApptCommand(Nric nric, Date date, TimePeriod timePeriod, EditApptDescriptor editApptDescriptor) {
+        requireNonNull(nric);
+        requireNonNull(date);
+        requireNonNull(timePeriod);
+        requireNonNull(editApptDescriptor);
+
+        this.targetNric = nric;
+        this.targetDate = date;
+        this.targetTimePeriod = timePeriod;
+        this.editApptDescriptor = new EditApptDescriptor(editApptDescriptor);
+        this.apptToEdit = null;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        if (!model.hasPatientWithNric(targetNric)) {
+            throw new CommandException(Messages.MESSAGE_PATIENT_NRIC_NOT_FOUND);
+        }
+
+        Appointment mockAppointmentToMatch = new Appointment(targetNric, targetDate, targetTimePeriod,
+                new AppointmentType("Anything"), new Note("Anything"), new Mark(false));
+        if (!model.hasAppointment(mockAppointmentToMatch)) {
+            throw new CommandException(Messages.MESSAGE_APPOINTMENT_NOT_FOUND);
+        }
+
+        this.apptToEdit = model.getMatchingAppointment(targetNric, targetDate, targetTimePeriod);
+
+        Appointment editedAppointment = createEditedAppointment(apptToEdit, editApptDescriptor);
+        model.setAppointment(apptToEdit, editedAppointment);
+        model.updateFilteredAppointmentList(PREDICATE_SHOW_ALL_APPOINTMENT_VIEWS);
+        return new CommandResult(String.format(MESSAGE_EDIT_APPT_SUCCESS, Messages.format(editedAppointment)));
+    }
+
+    /**
+     * Creates and returns a {@code Appointment} with the details of {@code apptToEdit}
+     * edited with {@code editAppointmentDescriptor}.
+     */
+    private static Appointment createEditedAppointment(Appointment apptToEdit, EditApptDescriptor editApptDescriptor) {
+        assert apptToEdit != null;
+
+        Date updatedDate = editApptDescriptor.getDate().orElse(apptToEdit.getDate());
+        TimePeriod updatedTimePeriod = editApptDescriptor.getTimePeriod().orElse(apptToEdit.getTimePeriod());
+        AppointmentType updatedAppointmentType = editApptDescriptor.getAppointmentType().orElse(apptToEdit.getAppointmentType());
+        Note updatedNote = editApptDescriptor.getNote().orElse(apptToEdit.getNote());
+
+        return new Appointment(apptToEdit.getNric(), updatedDate, updatedTimePeriod,
+                updatedAppointmentType, updatedNote, apptToEdit.getMark());
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof EditApptCommand)) {
+            return false;
+        }
+
+        EditApptCommand otherEditApptCommand = (EditApptCommand) other;
+        return targetNric.equals(otherEditApptCommand.targetNric)
+                && editApptDescriptor.equals(otherEditApptCommand.editApptDescriptor);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("nric", targetNric)
+                .add("date", targetDate)
+                .add("timePeriod", targetTimePeriod)
+                .add("editApptDescriptor", editApptDescriptor)
+                .toString();
+    }
+
+    /**
+     * Stores the details to edit the appointment with. Each non-empty field value will replace the
+     * corresponding field value of the appointment;
+     * Nric cannot be edited.
+     */
+    public static class EditApptDescriptor {
+        private Date date;
+        private TimePeriod timePeriod;
+        private AppointmentType appointmentType;
+        private Note note;
+
+        public EditApptDescriptor() {}
+
+        /**
+         * Copy constructor.
+         */
+        public EditApptDescriptor(EditApptDescriptor toCopy) {
+            setDate(toCopy.date);
+            setTimePeriod(toCopy.timePeriod);
+            setAppointmentType(toCopy.appointmentType);
+            setNote(toCopy.note);
+        }
+
+        /**
+         * Returns true if at least one field is edited.
+         */
+        public boolean isAnyFieldEdited() {
+            return CollectionUtil.isAnyNonNull(date, timePeriod, appointmentType, note);
+        }
+
+        public void setDate(Date date) {
+            this.date = date;
+        }
+
+        public Optional<Date> getDate() {
+            return Optional.ofNullable(date);
+        }
+
+        public void setTimePeriod(TimePeriod timePeriod) {
+            this.timePeriod = timePeriod;
+        }
+
+        public Optional<TimePeriod> getTimePeriod() {
+            return Optional.ofNullable(timePeriod);
+        }
+
+        public void setAppointmentType(AppointmentType appointmentType) {
+            this.appointmentType = appointmentType;
+        }
+
+        public Optional<AppointmentType> getAppointmentType() {
+            return Optional.ofNullable(appointmentType);
+        }
+
+        public void setNote(Note note) {
+            this.note = note;
+        }
+
+        public Optional<Note> getNote() {
+            return Optional.ofNullable(note);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            if (other == this) {
+                return true;
+            }
+
+            // instanceof handles nulls
+            if (!(other instanceof EditApptDescriptor)) {
+                return false;
+            }
+
+            EditApptDescriptor otherEditApptDescriptor = (EditApptDescriptor) other;
+            return Objects.equals(date, otherEditApptDescriptor.date)
+                    && Objects.equals(timePeriod, otherEditApptDescriptor.timePeriod)
+                    && Objects.equals(appointmentType, otherEditApptDescriptor.appointmentType)
+                    && Objects.equals(note, otherEditApptDescriptor.note);
+        }
+
+        @Override
+        public String toString() {
+            return new ToStringBuilder(this)
+                    .add("date", date)
+                    .add("timePeriod", timePeriod)
+                    .add("appointmentType", appointmentType)
+                    .add("note", note)
+                    .toString();
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/EditApptCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditApptCommand.java
@@ -118,7 +118,8 @@ public class EditApptCommand extends Command {
 
         Date updatedDate = editApptDescriptor.getDate().orElse(apptToEdit.getDate());
         TimePeriod updatedTimePeriod = editApptDescriptor.getTimePeriod().orElse(apptToEdit.getTimePeriod());
-        AppointmentType updatedAppointmentType = editApptDescriptor.getAppointmentType().orElse(apptToEdit.getAppointmentType());
+        AppointmentType updatedAppointmentType = editApptDescriptor.getAppointmentType()
+                .orElse(apptToEdit.getAppointmentType());
         Note updatedNote = editApptDescriptor.getNote().orElse(apptToEdit.getNote());
 
         return new Appointment(apptToEdit.getNric(), updatedDate, updatedTimePeriod,

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -14,6 +14,7 @@ import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteApptCommand;
 import seedu.address.logic.commands.DeletePatientCommand;
+import seedu.address.logic.commands.EditApptCommand;
 import seedu.address.logic.commands.EditPatientCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindApptCommand;
@@ -98,6 +99,10 @@ public class AddressBookParser {
         case DeleteApptCommand.COMMAND_WORD:
         case DeleteApptCommand.COMMAND_WORD_ALT:
             return new DeleteApptCommandParser().parse(arguments);
+
+        case EditApptCommand.COMMAND_WORD:
+        case EditApptCommand.COMMAND_WORD_ALT:
+            return new EditApptCommandParser().parse(arguments);
 
         case SwitchViewCommand.COMMAND_WORD:
             return new SwitchViewCommand();

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -17,4 +17,10 @@ public class CliSyntax {
     public static final Prefix PREFIX_START_TIME = new Prefix("from/");
     public static final Prefix PREFIX_END_TIME = new Prefix("to/");
     public static final Prefix PREFIX_NOTE = new Prefix("note/");
+
+    public static final Prefix PREFIX_NEW_TAG = new Prefix("newt/");
+    public static final Prefix PREFIX_NEW_DATE = new Prefix("newd/");
+    public static final Prefix PREFIX_NEW_START_TIME = new Prefix("newfrom/");
+    public static final Prefix PREFIX_NEW_END_TIME = new Prefix("newto/");
+    public static final Prefix PREFIX_NEW_NOTE = new Prefix("newnote/");
 }

--- a/src/main/java/seedu/address/logic/parser/EditApptCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditApptCommandParser.java
@@ -2,38 +2,23 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_DOB;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_END_TIME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NEW_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NEW_END_TIME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NEW_NOTE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NEW_START_TIME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NEW_TAG;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_START_TIME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Stream;
 
 import seedu.address.commons.core.date.Date;
-import seedu.address.logic.commands.DeleteApptCommand;
 import seedu.address.logic.commands.EditApptCommand;
-import seedu.address.logic.commands.EditPatientCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.appointment.Time;
 import seedu.address.model.appointment.TimePeriod;
 import seedu.address.model.patient.Nric;
-import seedu.address.model.tag.Tag;
 
 /**
  * Parses input arguments and creates a new EditApptCommand object
@@ -74,26 +59,30 @@ public class EditApptCommandParser implements Parser<EditApptCommand> {
         if (argMultimap.getValue(PREFIX_NEW_DATE).isPresent()) {
             editApptDescriptor.setDate(ParserUtil.parseDate(argMultimap.getValue(PREFIX_NEW_DATE).get()));
         }
-        if (argMultimap.getValue(PREFIX_NEW_START_TIME).isPresent() && argMultimap.getValue(PREFIX_NEW_END_TIME).isPresent()) {
+        if (argMultimap.getValue(PREFIX_NEW_START_TIME).isPresent()
+                && argMultimap.getValue(PREFIX_NEW_END_TIME).isPresent()) {
             //with both new times
             editApptDescriptor.setTimePeriod(ParserUtil.parseTimePeriod(
                     argMultimap.getValue(PREFIX_NEW_START_TIME).get(),
                     argMultimap.getValue(PREFIX_NEW_END_TIME).get()));
         }
-        if (argMultimap.getValue(PREFIX_NEW_START_TIME).isPresent() && argMultimap.getValue(PREFIX_NEW_END_TIME).isEmpty()) {
+        if (argMultimap.getValue(PREFIX_NEW_START_TIME).isPresent()
+                && argMultimap.getValue(PREFIX_NEW_END_TIME).isEmpty()) {
             //with old end time
             editApptDescriptor.setTimePeriod(ParserUtil.parseTimePeriod(
                     argMultimap.getValue(PREFIX_NEW_START_TIME).get(),
                     argMultimap.getValue(PREFIX_END_TIME).get()));
         }
-        if (argMultimap.getValue(PREFIX_NEW_START_TIME).isEmpty() && argMultimap.getValue(PREFIX_NEW_END_TIME).isPresent()) {
+        if (argMultimap.getValue(PREFIX_NEW_START_TIME).isEmpty()
+                && argMultimap.getValue(PREFIX_NEW_END_TIME).isPresent()) {
             //with old start time
             editApptDescriptor.setTimePeriod(ParserUtil.parseTimePeriod(
                     argMultimap.getValue(PREFIX_START_TIME).get(),
                     argMultimap.getValue(PREFIX_NEW_END_TIME).get()));
         }
         if (argMultimap.getValue(PREFIX_NEW_TAG).isPresent()) {
-            editApptDescriptor.setAppointmentType(ParserUtil.parseAppointmentType(argMultimap.getValue(PREFIX_NEW_TAG).get()));
+            editApptDescriptor.setAppointmentType(ParserUtil
+                    .parseAppointmentType(argMultimap.getValue(PREFIX_NEW_TAG).get()));
         }
         if (argMultimap.getValue(PREFIX_NEW_NOTE).isPresent()) {
             editApptDescriptor.setNote(ParserUtil.parseNote(argMultimap.getValue(PREFIX_NEW_NOTE).get()));

--- a/src/main/java/seedu/address/logic/parser/EditApptCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditApptCommandParser.java
@@ -1,0 +1,118 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DOB;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_END_TIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NEW_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NEW_END_TIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NEW_NOTE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NEW_START_TIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NEW_TAG;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_START_TIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import seedu.address.commons.core.date.Date;
+import seedu.address.logic.commands.DeleteApptCommand;
+import seedu.address.logic.commands.EditApptCommand;
+import seedu.address.logic.commands.EditPatientCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.appointment.Time;
+import seedu.address.model.appointment.TimePeriod;
+import seedu.address.model.patient.Nric;
+import seedu.address.model.tag.Tag;
+
+/**
+ * Parses input arguments and creates a new EditApptCommand object
+ */
+public class EditApptCommandParser implements Parser<EditApptCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the EditApptCommand
+     * and returns an EditApptCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public EditApptCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args,
+                PREFIX_NRIC, PREFIX_DATE, PREFIX_START_TIME, PREFIX_END_TIME,
+                PREFIX_NEW_DATE, PREFIX_NEW_START_TIME, PREFIX_NEW_END_TIME,
+                PREFIX_NEW_TAG, PREFIX_NEW_NOTE);
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_NRIC, PREFIX_DATE, PREFIX_START_TIME, PREFIX_END_TIME)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditApptCommand.MESSAGE_USAGE));
+        }
+
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NRIC, PREFIX_DATE, PREFIX_START_TIME,
+                PREFIX_END_TIME, PREFIX_NEW_DATE, PREFIX_NEW_START_TIME, PREFIX_NEW_END_TIME,
+                PREFIX_NEW_TAG, PREFIX_NEW_NOTE);
+
+        Nric targetNric = ParserUtil.parseNric(argMultimap.getValue(PREFIX_NRIC).get());
+        Date targetDate = ParserUtil.parseDate(argMultimap.getValue(PREFIX_DATE).get());
+        TimePeriod targetTimePeriod = ParserUtil.parseTimePeriod(
+                argMultimap.getValue(PREFIX_START_TIME).get(),
+                argMultimap.getValue(PREFIX_END_TIME).get());
+
+
+
+        EditApptCommand.EditApptDescriptor editApptDescriptor = new EditApptCommand.EditApptDescriptor();
+
+        if (argMultimap.getValue(PREFIX_NEW_DATE).isPresent()) {
+            editApptDescriptor.setDate(ParserUtil.parseDate(argMultimap.getValue(PREFIX_NEW_DATE).get()));
+        }
+        if (argMultimap.getValue(PREFIX_NEW_START_TIME).isPresent() && argMultimap.getValue(PREFIX_NEW_END_TIME).isPresent()) {
+            //with both new times
+            editApptDescriptor.setTimePeriod(ParserUtil.parseTimePeriod(
+                    argMultimap.getValue(PREFIX_NEW_START_TIME).get(),
+                    argMultimap.getValue(PREFIX_NEW_END_TIME).get()));
+        }
+        if (argMultimap.getValue(PREFIX_NEW_START_TIME).isPresent() && argMultimap.getValue(PREFIX_NEW_END_TIME).isEmpty()) {
+            //with old end time
+            editApptDescriptor.setTimePeriod(ParserUtil.parseTimePeriod(
+                    argMultimap.getValue(PREFIX_NEW_START_TIME).get(),
+                    argMultimap.getValue(PREFIX_END_TIME).get()));
+        }
+        if (argMultimap.getValue(PREFIX_NEW_START_TIME).isEmpty() && argMultimap.getValue(PREFIX_NEW_END_TIME).isPresent()) {
+            //with old start time
+            editApptDescriptor.setTimePeriod(ParserUtil.parseTimePeriod(
+                    argMultimap.getValue(PREFIX_START_TIME).get(),
+                    argMultimap.getValue(PREFIX_NEW_END_TIME).get()));
+        }
+        if (argMultimap.getValue(PREFIX_NEW_TAG).isPresent()) {
+            editApptDescriptor.setAppointmentType(ParserUtil.parseAppointmentType(argMultimap.getValue(PREFIX_NEW_TAG).get()));
+        }
+        if (argMultimap.getValue(PREFIX_NEW_NOTE).isPresent()) {
+            editApptDescriptor.setNote(ParserUtil.parseNote(argMultimap.getValue(PREFIX_NEW_NOTE).get()));
+        }
+
+
+        if (!editApptDescriptor.isAnyFieldEdited()) {
+            throw new ParseException(EditApptCommand.MESSAGE_EDIT_APPT_NO_FIELDS_FAILURE);
+        }
+
+        return new EditApptCommand(targetNric, targetDate, targetTimePeriod, editApptDescriptor);
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+
+}

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -26,6 +26,7 @@ import seedu.address.model.Model;
 import seedu.address.model.appointment.AppointmentView;
 import seedu.address.model.patient.NameContainsKeywordsPredicate;
 import seedu.address.model.patient.Patient;
+import seedu.address.testutil.EditApptDescriptorBuilder;
 import seedu.address.testutil.EditPatientDescriptorBuilder;
 import seedu.address.ui.ViewMode;
 
@@ -123,6 +124,22 @@ public class CommandTestUtil {
         DESC_BOB = new EditPatientDescriptorBuilder().withName(VALID_NAME_BOB)
                 .withDateOfBirth(VALID_DOB_BOB).withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_BOB)
                 .withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
+    }
+
+    public static final EditApptCommand.EditApptDescriptor DESC_APPT_AMY;
+    public static final EditApptCommand.EditApptDescriptor DESC_APPT_BOB;
+
+    static {
+        DESC_APPT_AMY = new EditApptDescriptorBuilder()
+                .withDate(VALID_APPOINTMENT_DATE_AMY)
+                .withTimePeriod(VALID_APPOINTMENT_START_TIME_AMY, VALID_APPOINTMENT_END_TIME_AMY)
+                .withAppointmentType(VALID_APPOINTMENT_TYPE_AMY)
+                .withNote(VALID_APPOINTMENT_NOTE_AMY).build();
+        DESC_APPT_BOB = new EditApptDescriptorBuilder()
+                .withDate(VALID_APPOINTMENT_DATE_BOB)
+                .withTimePeriod(VALID_APPOINTMENT_START_TIME_BOB, VALID_APPOINTMENT_END_TIME_BOB)
+                .withAppointmentType(VALID_APPOINTMENT_TYPE_BOB)
+                .withNote(VALID_APPOINTMENT_NOTE_BOB).build();
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -8,6 +8,11 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_DOB;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_END_TIME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NEW_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NEW_END_TIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NEW_NOTE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NEW_START_TIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NEW_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
@@ -78,6 +83,8 @@ public class CommandTestUtil {
     public static final String TAG_DESC_HUSBAND = " " + PREFIX_TAG + VALID_TAG_HUSBAND;
     public static final String DATE_DESC_APPOINTMENT_AMY = " " + PREFIX_DATE + VALID_APPOINTMENT_DATE_AMY;
     public static final String DATE_DESC_APPOINTMENT_BOB = " " + PREFIX_DATE + VALID_APPOINTMENT_DATE_BOB;
+    public static final String NEW_DATE_DESC_APPOINTMENT_AMY = " " + PREFIX_NEW_DATE + VALID_APPOINTMENT_DATE_AMY;
+    public static final String NEW_DATE_DESC_APPOINTMENT_BOB = " " + PREFIX_NEW_DATE + VALID_APPOINTMENT_DATE_BOB;
     public static final String START_TIME_DESC_APPOINTMENT_AMY = " " + PREFIX_START_TIME
             + VALID_APPOINTMENT_START_TIME_AMY;
     public static final String END_TIME_DESC_APPOINTMENT_AMY = " " + PREFIX_END_TIME
@@ -86,10 +93,22 @@ public class CommandTestUtil {
             + VALID_APPOINTMENT_START_TIME_BOB;
     public static final String END_TIME_DESC_APPOINTMENT_BOB = " " + PREFIX_END_TIME
             + VALID_APPOINTMENT_END_TIME_BOB;
+    public static final String NEW_START_TIME_DESC_APPOINTMENT_AMY = " " + PREFIX_NEW_START_TIME
+            + VALID_APPOINTMENT_START_TIME_AMY;
+    public static final String NEW_START_TIME_DESC_APPOINTMENT_BOB = " " + PREFIX_NEW_START_TIME
+            + VALID_APPOINTMENT_START_TIME_BOB;
+    public static final String NEW_END_TIME_DESC_APPOINTMENT_AMY= " " + PREFIX_NEW_END_TIME
+            + VALID_APPOINTMENT_END_TIME_AMY;
+    public static final String NEW_END_TIME_DESC_APPOINTMENT_BOB = " " + PREFIX_NEW_END_TIME
+            + VALID_APPOINTMENT_END_TIME_BOB;
     public static final String TYPE_DESC_APPOINTMENT_AMY = " " + PREFIX_TAG + VALID_APPOINTMENT_TYPE_AMY;
     public static final String TYPE_DESC_APPOINTMENT_BOB = " " + PREFIX_TAG + VALID_APPOINTMENT_TYPE_BOB;
+    public static final String NEW_TYPE_DESC_APPOINTMENT_AMY = " " + PREFIX_NEW_TAG + VALID_APPOINTMENT_TYPE_AMY;
+    public static final String NEW_TYPE_DESC_APPOINTMENT_BOB = " " + PREFIX_NEW_TAG + VALID_APPOINTMENT_TYPE_BOB;
     public static final String NOTE_DESC_APPOINTMENT_AMY = " " + PREFIX_NOTE + VALID_APPOINTMENT_NOTE_AMY;
     public static final String NOTE_DESC_APPOINTMENT_BOB = " " + PREFIX_NOTE + VALID_APPOINTMENT_NOTE_BOB;
+    public static final String NEW_NOTE_DESC_APPOINTMENT_AMY = " " + PREFIX_NEW_NOTE + VALID_APPOINTMENT_NOTE_AMY;
+    public static final String NEW_NOTE_DESC_APPOINTMENT_BOB = " " + PREFIX_NEW_NOTE + VALID_APPOINTMENT_NOTE_BOB;
     public static final String MARK_DESC_APPOINTMENT_AMY = " " + PREFIX_NOTE + VALID_APPOINTMENT_MARK_AMY;
     public static final String MARK_DESC_APPOINTMENT_BOB = " " + PREFIX_NOTE + VALID_APPOINTMENT_MARK_BOB;
 
@@ -108,6 +127,11 @@ public class CommandTestUtil {
     public static final String INVALID_APPOINTMENT_TYPE_DESC = " " + PREFIX_TAG + "  "; // only white spaces
     public static final String INVALID_APPOINTMENT_NOTE_DESC = " " + PREFIX_NOTE + "@@"; // non-alphanumeric
     public static final String INVALID_APPOINTMENT_MARK_DESC = " " + PREFIX_NOTE + "abc"; // not true or false
+    public static final String INVALID_NEW_DATE_DESC = " " + PREFIX_NEW_DATE + "2024-32-32"; // exceeds month and day range
+    public static final String INVALID_NEW_START_TIME_DESC = " " + PREFIX_NEW_START_TIME + "11:30"; // is after end time
+    public static final String INVALID_NEW_END_TIME_DESC = " " + PREFIX_NEW_END_TIME + "11:00"; // is before start time
+    public static final String INVALID_NEW_APPOINTMENT_TYPE_DESC = " " + PREFIX_NEW_TAG + "  "; // only white spaces
+    public static final String INVALID_NEW_APPOINTMENT_NOTE_DESC = " " + PREFIX_NEW_NOTE + "@@"; // non-alphanumeric
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
     public static final String PREAMBLE_NON_EMPTY = "NonEmptyPreamble";
 

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -97,7 +97,7 @@ public class CommandTestUtil {
             + VALID_APPOINTMENT_START_TIME_AMY;
     public static final String NEW_START_TIME_DESC_APPOINTMENT_BOB = " " + PREFIX_NEW_START_TIME
             + VALID_APPOINTMENT_START_TIME_BOB;
-    public static final String NEW_END_TIME_DESC_APPOINTMENT_AMY= " " + PREFIX_NEW_END_TIME
+    public static final String NEW_END_TIME_DESC_APPOINTMENT_AMY = " " + PREFIX_NEW_END_TIME
             + VALID_APPOINTMENT_END_TIME_AMY;
     public static final String NEW_END_TIME_DESC_APPOINTMENT_BOB = " " + PREFIX_NEW_END_TIME
             + VALID_APPOINTMENT_END_TIME_BOB;
@@ -127,7 +127,7 @@ public class CommandTestUtil {
     public static final String INVALID_APPOINTMENT_TYPE_DESC = " " + PREFIX_TAG + "  "; // only white spaces
     public static final String INVALID_APPOINTMENT_NOTE_DESC = " " + PREFIX_NOTE + "@@"; // non-alphanumeric
     public static final String INVALID_APPOINTMENT_MARK_DESC = " " + PREFIX_NOTE + "abc"; // not true or false
-    public static final String INVALID_NEW_DATE_DESC = " " + PREFIX_NEW_DATE + "2024-32-32"; // exceeds month and day range
+    public static final String INVALID_NEW_DATE_DESC = " " + PREFIX_NEW_DATE + "2024-32-32"; //exceeds month & day range
     public static final String INVALID_NEW_START_TIME_DESC = " " + PREFIX_NEW_START_TIME + "11:30"; // is after end time
     public static final String INVALID_NEW_END_TIME_DESC = " " + PREFIX_NEW_END_TIME + "11:00"; // is before start time
     public static final String INVALID_NEW_APPOINTMENT_TYPE_DESC = " " + PREFIX_NEW_TAG + "  "; // only white spaces

--- a/src/test/java/seedu/address/logic/commands/EditApptCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditApptCommandTest.java
@@ -1,0 +1,182 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_APPOINTMENT_DATE_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_APPOINTMENT_DATE_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_APPOINTMENT_END_TIME_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_APPOINTMENT_NOTE_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_APPOINTMENT_START_TIME_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NRIC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NRIC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+
+import seedu.address.commons.core.date.Date;
+import seedu.address.logic.commands.EditApptCommand.EditApptDescriptor;
+import static seedu.address.testutil.TypicalAppointments.ALICE_APPT;
+import static seedu.address.testutil.TypicalAppointments.getTypicalAddressBookWithAppointments;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.Messages;
+import seedu.address.model.AddressBook;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.appointment.Appointment;
+import seedu.address.model.appointment.Time;
+import seedu.address.model.appointment.TimePeriod;
+import seedu.address.model.patient.Nric;
+import seedu.address.testutil.AppointmentBuilder;
+import seedu.address.testutil.EditApptDescriptorBuilder;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for EditApptCommand.
+ */
+public class EditApptCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBookWithAppointments(), new UserPrefs());
+
+    //All fields specified with same as original appt
+    @Test
+    public void execute_allFieldsSpecified_success() {
+        Appointment editedAppt = new AppointmentBuilder().withNric(ALICE_APPT.getNric().value).build();
+        EditApptCommand.EditApptDescriptor descriptor = new EditApptDescriptorBuilder(editedAppt).build();
+        EditApptCommand editApptCommand = new EditApptCommand(ALICE_APPT.getNric(), ALICE_APPT.getDate(),
+                ALICE_APPT.getTimePeriod(), descriptor);
+
+        String expectedMessage = String.format(EditApptCommand.MESSAGE_EDIT_APPT_SUCCESS,
+                Messages.format(editedAppt));
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setAppointment(ALICE_APPT, editedAppt);
+
+        assertCommandSuccess(editApptCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_someFieldsSpecified_success() {
+        AppointmentBuilder appointmentInList = new AppointmentBuilder(ALICE_APPT);
+        Appointment editedAppt = appointmentInList.withDate(VALID_APPOINTMENT_DATE_AMY)
+                .withStartTime(VALID_APPOINTMENT_START_TIME_AMY).withEndTime(VALID_APPOINTMENT_END_TIME_AMY).build();
+
+        EditApptDescriptor descriptor = new EditApptDescriptorBuilder().withDate(VALID_APPOINTMENT_DATE_AMY)
+                .withTimePeriod(VALID_APPOINTMENT_START_TIME_AMY, VALID_APPOINTMENT_END_TIME_AMY).build();
+        EditApptCommand editApptCommand = new EditApptCommand(ALICE_APPT.getNric(),
+                ALICE_APPT.getDate(), ALICE_APPT.getTimePeriod(), descriptor);
+
+        String expectedMessage = String.format(EditApptCommand.MESSAGE_EDIT_APPT_SUCCESS,
+                Messages.format(editedAppt));
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        expectedModel.setAppointment(ALICE_APPT, editedAppt);
+
+        assertCommandSuccess(editApptCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_noFieldSpecified_success() {
+        EditApptCommand editApptCommand =
+                new EditApptCommand(ALICE_APPT.getNric(),
+                        ALICE_APPT.getDate(), ALICE_APPT.getTimePeriod(), new EditApptCommand.EditApptDescriptor());
+        Appointment editedAppointment = model.getMatchingAppointment(ALICE_APPT.getNric(),
+                ALICE_APPT.getDate(), ALICE_APPT.getTimePeriod());
+
+        String expectedMessage = String.format(EditApptCommand.MESSAGE_EDIT_APPT_SUCCESS,
+                Messages.format(editedAppointment));
+
+        Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+
+        assertEquals(ALICE_APPT, editedAppointment);
+        assertCommandSuccess(editApptCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_appointmentNricNotFound_failure() {
+        Nric notFoundNric = new Nric("G9999999X");
+        EditApptDescriptor descriptor = new EditApptDescriptorBuilder().withDate(VALID_APPOINTMENT_DATE_AMY).build();
+        EditApptCommand editApptCommand = new EditApptCommand(notFoundNric,
+                ALICE_APPT.getDate(), ALICE_APPT.getTimePeriod(), descriptor);
+
+        assertCommandFailure(editApptCommand, model, Messages.MESSAGE_PATIENT_NRIC_NOT_FOUND);
+    }
+
+    @Test
+    public void execute_appointmentNotFound_failure() {
+        EditApptDescriptor descriptor = new EditApptDescriptorBuilder().withDate(VALID_APPOINTMENT_DATE_AMY).build();
+        EditApptCommand editApptCommand = new EditApptCommand(
+                ALICE_APPT.getNric(),
+                new Date("1900-02-02"),
+                ALICE_APPT.getTimePeriod(),
+                descriptor
+        );
+
+        assertCommandFailure(editApptCommand, model, Messages.MESSAGE_APPOINTMENT_NOT_FOUND);
+    }
+
+    @Test
+    public void equals() {
+        final EditApptDescriptor descriptor = new EditApptDescriptorBuilder()
+                .withDate(VALID_APPOINTMENT_DATE_BOB).build();
+        final EditApptCommand standardCommand = new EditApptCommand(
+                new Nric(VALID_NRIC_AMY),
+                new Date(VALID_APPOINTMENT_DATE_AMY),
+                new TimePeriod(new Time(VALID_APPOINTMENT_START_TIME_AMY), new Time(VALID_APPOINTMENT_END_TIME_AMY)),
+                descriptor);
+
+        // same values -> returns true
+        EditApptDescriptor copyDescriptor = new EditApptCommand.EditApptDescriptor(descriptor);
+        EditApptCommand commandWithSameValues = new EditApptCommand(
+                new Nric(VALID_NRIC_AMY),
+                new Date(VALID_APPOINTMENT_DATE_AMY),
+                new TimePeriod(new Time(VALID_APPOINTMENT_START_TIME_AMY), new Time(VALID_APPOINTMENT_END_TIME_AMY)),
+                copyDescriptor);
+        assertTrue(standardCommand.equals(commandWithSameValues));
+
+        // same object -> returns true
+        assertTrue(standardCommand.equals(standardCommand));
+
+        // null -> returns false
+        assertFalse(standardCommand.equals(null));
+
+        // different types -> returns false
+        assertFalse(standardCommand.equals(new ClearCommand()));
+
+        // different nric -> returns false
+        assertFalse(standardCommand.equals(new EditApptCommand(
+                new Nric(VALID_NRIC_BOB),
+                new Date(VALID_APPOINTMENT_DATE_AMY),
+                new TimePeriod(new Time(VALID_APPOINTMENT_START_TIME_AMY), new Time(VALID_APPOINTMENT_END_TIME_AMY)),
+                descriptor)));
+
+        final EditApptDescriptor diffDescriptor = new EditApptDescriptorBuilder()
+                .withNote(VALID_APPOINTMENT_NOTE_BOB).build();
+
+        // different descriptor -> returns false
+        assertFalse(standardCommand.equals(new EditApptCommand(
+                new Nric(VALID_NRIC_AMY),
+                new Date(VALID_APPOINTMENT_DATE_AMY),
+                new TimePeriod(new Time(VALID_APPOINTMENT_START_TIME_AMY), new Time(VALID_APPOINTMENT_END_TIME_AMY)),
+                diffDescriptor)));
+    }
+
+    @Test
+    public void toStringMethod() {
+        EditApptCommand.EditApptDescriptor editApptDescriptor = new EditApptDescriptor();
+        EditApptCommand editApptCommand = new EditApptCommand(
+                new Nric(VALID_NRIC_AMY),
+                new Date(VALID_APPOINTMENT_DATE_AMY),
+                new TimePeriod(new Time(VALID_APPOINTMENT_START_TIME_AMY), new Time(VALID_APPOINTMENT_END_TIME_AMY)),
+                editApptDescriptor);
+        String expected = EditApptCommand.class.getCanonicalName()
+                + "{nric=" + VALID_NRIC_AMY
+                + ", date=" + VALID_APPOINTMENT_DATE_AMY
+                + ", timePeriod=" + VALID_APPOINTMENT_START_TIME_AMY
+                + " to " + VALID_APPOINTMENT_END_TIME_AMY
+                + ", editApptDescriptor=" + editApptDescriptor + "}";
+        assertEquals(expected, editApptCommand.toString());
+    }
+
+}

--- a/src/test/java/seedu/address/logic/commands/EditApptCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditApptCommandTest.java
@@ -12,15 +12,14 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_NRIC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NRIC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
-
-import seedu.address.commons.core.date.Date;
-import seedu.address.logic.commands.EditApptCommand.EditApptDescriptor;
 import static seedu.address.testutil.TypicalAppointments.ALICE_APPT;
 import static seedu.address.testutil.TypicalAppointments.getTypicalAddressBookWithAppointments;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.commons.core.date.Date;
 import seedu.address.logic.Messages;
+import seedu.address.logic.commands.EditApptCommand.EditApptDescriptor;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;

--- a/src/test/java/seedu/address/logic/commands/EditApptDescriptorTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditApptDescriptorTest.java
@@ -1,0 +1,70 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.DESC_APPT_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.DESC_APPT_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_APPOINTMENT_DATE_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_APPOINTMENT_END_TIME_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_APPOINTMENT_NOTE_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_APPOINTMENT_START_TIME_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_APPOINTMENT_TYPE_BOB;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.EditApptCommand.EditApptDescriptor;
+import seedu.address.testutil.EditApptDescriptorBuilder;
+
+public class EditApptDescriptorTest {
+
+    @Test
+    public void equals() {
+        // same values -> returns true
+        EditApptDescriptor descriptorWithSameValues = new EditApptCommand.EditApptDescriptor(DESC_APPT_AMY);
+        assertTrue(DESC_APPT_AMY.equals(descriptorWithSameValues));
+
+        // same object -> returns true
+        assertTrue(DESC_APPT_AMY.equals(DESC_APPT_AMY));
+
+        // null -> returns false
+        assertFalse(DESC_APPT_AMY.equals(null));
+
+        // different types -> returns false
+        assertFalse(DESC_APPT_AMY.equals(5));
+
+        // different values -> returns false
+        assertFalse(DESC_APPT_AMY.equals(DESC_APPT_BOB));
+
+        // different date -> returns false
+        EditApptDescriptor editedAmyAppt = new EditApptDescriptorBuilder(DESC_APPT_AMY)
+                .withDate(VALID_APPOINTMENT_DATE_BOB).build();
+        assertFalse(DESC_APPT_AMY.equals(editedAmyAppt));
+
+        // different timePeriod -> returns false
+        editedAmyAppt = new EditApptDescriptorBuilder(DESC_APPT_AMY)
+                .withTimePeriod(VALID_APPOINTMENT_START_TIME_BOB, VALID_APPOINTMENT_END_TIME_BOB).build();
+        assertFalse(DESC_APPT_AMY.equals(editedAmyAppt));
+
+        // different appointmentType -> returns false
+        editedAmyAppt = new EditApptDescriptorBuilder(DESC_APPT_AMY)
+                .withAppointmentType(VALID_APPOINTMENT_TYPE_BOB).build();
+        assertFalse(DESC_APPT_AMY.equals(editedAmyAppt));
+
+        // different note -> returns false
+        editedAmyAppt = new EditApptDescriptorBuilder(DESC_APPT_AMY)
+                .withNote(VALID_APPOINTMENT_NOTE_BOB).build();
+        assertFalse(DESC_APPT_AMY.equals(editedAmyAppt));
+    }
+
+    @Test
+    public void toStringMethod() {
+        EditApptDescriptor editApptDescriptor = new EditApptDescriptor();
+        String expected = EditApptDescriptor.class.getCanonicalName() + "{date="
+                + editApptDescriptor.getDate().orElse(null) + ", timePeriod="
+                + editApptDescriptor.getTimePeriod().orElse(null) + ", appointmentType="
+                + editApptDescriptor.getAppointmentType().orElse(null) + ", note="
+                + editApptDescriptor.getNote().orElse(null) + "}";
+        assertEquals(expected, editApptDescriptor.toString());
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -48,7 +48,7 @@ public class AddressBookParserTest {
     }
 
     @Test
-    public void parseCommand_appAppt() throws Exception {
+    public void parseCommand_addAppt() throws Exception {
         Appointment appointment = new AppointmentBuilder().build();
         AddApptCommand command = (AddApptCommand) parser.parseCommand(AppointmentUtil.getAddApptCommand(appointment));
         assertEquals(new AddApptCommand(appointment), command);

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -15,7 +15,9 @@ import org.junit.jupiter.api.Test;
 import seedu.address.logic.commands.AddApptCommand;
 import seedu.address.logic.commands.AddPatientCommand;
 import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.commands.DeleteApptCommand;
 import seedu.address.logic.commands.DeletePatientCommand;
+import seedu.address.logic.commands.EditApptCommand;
 import seedu.address.logic.commands.EditPatientCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindPatientCommand;
@@ -29,6 +31,7 @@ import seedu.address.model.patient.NricContainsMatchPredicate;
 import seedu.address.model.patient.Patient;
 import seedu.address.testutil.AppointmentBuilder;
 import seedu.address.testutil.AppointmentUtil;
+import seedu.address.testutil.EditApptDescriptorBuilder;
 import seedu.address.testutil.EditPatientDescriptorBuilder;
 import seedu.address.testutil.PatientBuilder;
 import seedu.address.testutil.PatientUtil;
@@ -38,16 +41,16 @@ public class AddressBookParserTest {
     private final AddressBookParser parser = new AddressBookParser();
 
     @Test
-    public void parseCommand_add() throws Exception {
+    public void parseCommand_addPatient() throws Exception {
         Patient patient = new PatientBuilder().build();
         AddPatientCommand command = (AddPatientCommand) parser.parseCommand(PatientUtil.getAddCommand(patient));
         assertEquals(new AddPatientCommand(patient), command);
     }
 
     @Test
-    public void parseCommand_appApp() throws Exception {
+    public void parseCommand_appAppt() throws Exception {
         Appointment appointment = new AppointmentBuilder().build();
-        AddApptCommand command = (AddApptCommand) parser.parseCommand(AppointmentUtil.getAddAppCommand(appointment));
+        AddApptCommand command = (AddApptCommand) parser.parseCommand(AppointmentUtil.getAddApptCommand(appointment));
         assertEquals(new AddApptCommand(appointment), command);
     }
 
@@ -58,7 +61,7 @@ public class AddressBookParserTest {
     }
 
     @Test
-    public void parseCommand_delete() throws Exception {
+    public void parseCommand_deletePatient() throws Exception {
         Patient patient = new PatientBuilder().build();
         DeletePatientCommand command = (DeletePatientCommand) parser.parseCommand(
                 DeletePatientCommand.COMMAND_WORD + " " + patient.getNric());
@@ -67,12 +70,31 @@ public class AddressBookParserTest {
     }
 
     @Test
-    public void parseCommand_edit() throws Exception {
+    public void parseCommand_deleteAppt() throws Exception {
+        Appointment appt = new AppointmentBuilder().build();
+        DeleteApptCommand command = (DeleteApptCommand) parser.parseCommand(AppointmentUtil
+                .getDeleteApptCommand(appt));
+
+        assertEquals(new DeleteApptCommand(appt.getNric(), appt.getDate(), appt.getTimePeriod()), command);
+    }
+
+    @Test
+    public void parseCommand_editPatient() throws Exception {
         Patient patient = new PatientBuilder().build();
         EditPatientCommand.EditPatientDescriptor descriptor = new EditPatientDescriptorBuilder(patient).build();
         EditPatientCommand command = (EditPatientCommand) parser.parseCommand(EditPatientCommand.COMMAND_WORD + " "
                 + patient.getNric() + " " + PatientUtil.getEditPatientDescriptorDetails(descriptor));
         assertEquals(new EditPatientCommand(patient.getNric(), descriptor), command);
+    }
+
+    @Test
+    public void parseCommand_editAppt() throws Exception {
+        Appointment appt = new AppointmentBuilder().build();
+        EditApptCommand.EditApptDescriptor descriptor = new EditApptDescriptorBuilder(appt).build();
+        EditApptCommand command = (EditApptCommand) parser.parseCommand(EditApptCommand.COMMAND_WORD
+                + " " + AppointmentUtil.getAppointmentUniqueDetails(appt)
+                + " " + AppointmentUtil.getEditApptDescriptorDetails(descriptor));
+        assertEquals(new EditApptCommand(appt.getNric(), appt.getDate(), appt.getTimePeriod(), descriptor), command);
     }
 
     @Test
@@ -82,7 +104,7 @@ public class AddressBookParserTest {
     }
 
     @Test
-    public void parseCommand_find() throws Exception {
+    public void parseCommand_findPatient() throws Exception {
         List<String> keywords = Arrays.asList("foo", "bar", "baz");
         FindPatientCommand command = (FindPatientCommand) parser.parseCommand(
                 FindPatientCommand.COMMAND_WORD + " n/" + keywords.stream().collect(Collectors.joining(" ")));
@@ -104,13 +126,6 @@ public class AddressBookParserTest {
     public void parseCommand_list() throws Exception {
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);
-    }
-
-    @Test
-    public void parseCommand_addApp() throws Exception {
-        Appointment appointment = new AppointmentBuilder().build();
-        AddApptCommand command = (AddApptCommand) parser.parseCommand(AppointmentUtil.getAddAppCommand(appointment));
-        assertEquals(new AddApptCommand(appointment), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/EditApptCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditApptCommandParserTest.java
@@ -1,45 +1,43 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.DATE_DESC_APPOINTMENT_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_APPT_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.DOB_DESC_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.END_TIME_DESC_APPOINTMENT_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.END_TIME_DESC_APPOINTMENT_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_ADDRESS_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_DATE_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_DOB_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_END_TIME_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_NEW_APPOINTMENT_TYPE_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_NEW_DATE_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_NEW_END_TIME_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_NEW_START_TIME_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_NRIC_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_START_TIME_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.NEW_DATE_DESC_APPOINTMENT_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.NEW_DATE_DESC_APPOINTMENT_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.NEW_END_TIME_DESC_APPOINTMENT_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.NEW_END_TIME_DESC_APPOINTMENT_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.NEW_NOTE_DESC_APPOINTMENT_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.NEW_NOTE_DESC_APPOINTMENT_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.NEW_START_TIME_DESC_APPOINTMENT_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.NEW_START_TIME_DESC_APPOINTMENT_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.NEW_TYPE_DESC_APPOINTMENT_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.NEW_TYPE_DESC_APPOINTMENT_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.NRIC_DESC_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.START_TIME_DESC_APPOINTMENT_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
-import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_APPOINTMENT_DATE_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_APPOINTMENT_DATE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_APPOINTMENT_END_TIME_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_APPOINTMENT_END_TIME_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_APPOINTMENT_NOTE_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_APPOINTMENT_NOTE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_APPOINTMENT_START_TIME_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_DOB_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_APPOINTMENT_START_TIME_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_APPOINTMENT_TYPE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NRIC_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_NRIC_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NEW_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NEW_END_TIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NEW_START_TIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NEW_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
@@ -49,17 +47,12 @@ import org.junit.jupiter.api.Test;
 import seedu.address.commons.core.date.Date;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.EditApptCommand;
-import seedu.address.logic.commands.EditPatientCommand;
-import seedu.address.logic.commands.EditPatientCommand.EditPatientDescriptor;
+import seedu.address.logic.commands.EditApptCommand.EditApptDescriptor;
+import seedu.address.model.appointment.AppointmentType;
 import seedu.address.model.appointment.Time;
-import seedu.address.model.patient.Address;
-import seedu.address.model.patient.DateOfBirth;
-import seedu.address.model.patient.Email;
-import seedu.address.model.patient.Name;
+import seedu.address.model.appointment.TimePeriod;
 import seedu.address.model.patient.Nric;
-import seedu.address.model.patient.Phone;
-import seedu.address.model.tag.Tag;
-import seedu.address.testutil.EditPatientDescriptorBuilder;
+import seedu.address.testutil.EditApptDescriptorBuilder;
 
 public class EditApptCommandParserTest {
 
@@ -123,42 +116,79 @@ public class EditApptCommandParserTest {
 
     @Test
     public void parse_invalidValue_failure() {
+
+        String validTargetAppt = NRIC_DESC_AMY
+                + DATE_DESC_APPOINTMENT_AMY
+                + START_TIME_DESC_APPOINTMENT_AMY
+                + END_TIME_DESC_APPOINTMENT_AMY;
+
+        assertParseFailure(parser, INVALID_NRIC_DESC
+                + DATE_DESC_APPOINTMENT_AMY
+                + START_TIME_DESC_APPOINTMENT_AMY
+                + END_TIME_DESC_APPOINTMENT_AMY
+                + DESC_APPT_AMY, Nric.MESSAGE_CONSTRAINTS); // invalid nric
         assertParseFailure(parser, NRIC_DESC_AMY
-                + INVALID_DATE_DESC, Date.MESSAGE_CONSTRAINTS); // invalid date
-        assertParseFailure(parser, VALID_NRIC_AMY + INVALID_DOB_DESC, Time.MESSAGE_CONSTRAINTS); // invalid startTime
-        assertParseFailure(parser, VALID_NRIC_AMY + INVALID_PHONE_DESC, Time.MESSAGE_CONSTRAINTS); // invalid endTime
-        assertParseFailure(parser, VALID_NRIC_AMY + INVALID_EMAIL_DESC, Email.MESSAGE_CONSTRAINTS); // invalid new date
-        assertParseFailure(parser, VALID_NRIC_AMY
-                + INVALID_ADDRESS_DESC, Address.MESSAGE_CONSTRAINTS); // invalid address
-        assertParseFailure(parser, VALID_NRIC_AMY + INVALID_TAG_DESC, Tag.MESSAGE_CONSTRAINTS); // invalid tag
+                + INVALID_DATE_DESC
+                + START_TIME_DESC_APPOINTMENT_AMY
+                + END_TIME_DESC_APPOINTMENT_AMY
+                + DESC_APPT_AMY, Date.MESSAGE_CONSTRAINTS); // invalid date
+        assertParseFailure(parser, NRIC_DESC_AMY
+                + DATE_DESC_APPOINTMENT_AMY
+                + INVALID_START_TIME_DESC
+                + END_TIME_DESC_APPOINTMENT_AMY
+                + DESC_APPT_AMY, Time.MESSAGE_CONSTRAINTS); // invalid startTime
+        assertParseFailure(parser, NRIC_DESC_AMY
+                + DATE_DESC_APPOINTMENT_AMY
+                + START_TIME_DESC_APPOINTMENT_AMY
+                + INVALID_END_TIME_DESC
+                + DESC_APPT_AMY, Time.MESSAGE_CONSTRAINTS); // invalid endTime
 
-        // invalid phone followed by valid email
-        assertParseFailure(parser, VALID_NRIC_AMY + INVALID_PHONE_DESC + EMAIL_DESC_AMY, Phone.MESSAGE_CONSTRAINTS);
+        //More invalid tests here for the descriptors
+        assertParseFailure(parser, validTargetAppt
+         + INVALID_NEW_DATE_DESC , Date.MESSAGE_CONSTRAINTS); // invalid new date
+        assertParseFailure(parser, validTargetAppt
+                + INVALID_NEW_START_TIME_DESC , TimePeriod.MESSAGE_CONSTRAINTS); // invalid new startTime
+        assertParseFailure(parser, validTargetAppt
+                + INVALID_NEW_END_TIME_DESC , TimePeriod.MESSAGE_CONSTRAINTS); // invalid new endTime
+        assertParseFailure(parser, validTargetAppt
+                + INVALID_NEW_APPOINTMENT_TYPE_DESC , AppointmentType.MESSAGE_CONSTRAINTS); // invalid new appointmentType
 
-        // while parsing {@code PREFIX_TAG} alone will reset the tags of the {@code Patient} being edited,
-        // parsing it together with a valid tag results in error
-        assertParseFailure(parser, VALID_NRIC_AMY + TAG_DESC_FRIEND
-                + TAG_DESC_HUSBAND + TAG_EMPTY, Tag.MESSAGE_CONSTRAINTS);
-        assertParseFailure(parser, VALID_NRIC_AMY + TAG_DESC_FRIEND
-                + TAG_EMPTY + TAG_DESC_HUSBAND, Tag.MESSAGE_CONSTRAINTS);
-        assertParseFailure(parser, VALID_NRIC_AMY + TAG_EMPTY + TAG_DESC_FRIEND
-                + TAG_DESC_HUSBAND, Tag.MESSAGE_CONSTRAINTS);
+        //all notes are valid so no test for that
 
         // multiple invalid values, but only the first invalid value is captured
-        assertParseFailure(parser, VALID_NRIC_AMY + INVALID_NAME_DESC + INVALID_EMAIL_DESC
-                + VALID_ADDRESS_AMY + VALID_PHONE_AMY, Name.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, NRIC_DESC_AMY
+                + INVALID_DATE_DESC
+                + INVALID_START_TIME_DESC
+                + END_TIME_DESC_APPOINTMENT_AMY
+                + DESC_APPT_AMY, Date.MESSAGE_CONSTRAINTS);
     }
 
     @Test
     public void parse_allFieldsSpecified_success() {
         Nric targetNric = new Nric(VALID_NRIC_AMY);
-        String userInput = targetNric + PHONE_DESC_BOB + TAG_DESC_HUSBAND
-                + DOB_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + NAME_DESC_AMY + TAG_DESC_FRIEND;
+        Date targetDate = new Date(VALID_APPOINTMENT_DATE_AMY);
+        TimePeriod targetTimePeriod = new TimePeriod(
+                new Time(VALID_APPOINTMENT_START_TIME_AMY),
+                new Time(VALID_APPOINTMENT_END_TIME_AMY)
+        );
 
-        EditPatientDescriptor descriptor = new EditPatientDescriptorBuilder().withName(VALID_NAME_AMY)
-                .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY)
-                .withDateOfBirth(VALID_DOB_AMY).withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
-        EditPatientCommand expectedCommand = new EditPatientCommand(targetNric, descriptor);
+        String validTargetAppt = NRIC_DESC_AMY
+                + DATE_DESC_APPOINTMENT_AMY
+                + START_TIME_DESC_APPOINTMENT_AMY
+                + END_TIME_DESC_APPOINTMENT_AMY;
+
+        String userInput = validTargetAppt
+                + NEW_DATE_DESC_APPOINTMENT_BOB
+                + NEW_START_TIME_DESC_APPOINTMENT_BOB
+                + NEW_END_TIME_DESC_APPOINTMENT_BOB
+                + NEW_TYPE_DESC_APPOINTMENT_BOB
+                + NEW_NOTE_DESC_APPOINTMENT_BOB;
+
+        EditApptDescriptor descriptor = new EditApptDescriptorBuilder().withDate(VALID_APPOINTMENT_DATE_BOB)
+                .withTimePeriod(VALID_APPOINTMENT_START_TIME_BOB, VALID_APPOINTMENT_END_TIME_BOB)
+                .withAppointmentType(VALID_APPOINTMENT_TYPE_BOB).withNote(VALID_APPOINTMENT_NOTE_BOB)
+                .build();
+        EditApptCommand expectedCommand = new EditApptCommand(targetNric, targetDate, targetTimePeriod, descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
     }
@@ -166,53 +196,74 @@ public class EditApptCommandParserTest {
     @Test
     public void parse_someFieldsSpecified_success() {
         Nric targetNric = new Nric(VALID_NRIC_AMY);
-        String userInput = targetNric + PHONE_DESC_BOB + EMAIL_DESC_AMY;
+        Date targetDate = new Date(VALID_APPOINTMENT_DATE_AMY);
+        TimePeriod targetTimePeriod = new TimePeriod(
+                new Time(VALID_APPOINTMENT_START_TIME_AMY),
+                new Time(VALID_APPOINTMENT_END_TIME_AMY)
+        );
 
-        EditPatientCommand.EditPatientDescriptor descriptor =
-                new EditPatientDescriptorBuilder().withPhone(VALID_PHONE_BOB)
-                        .withEmail(VALID_EMAIL_AMY).build();
-        EditPatientCommand expectedCommand = new EditPatientCommand(targetNric, descriptor);
+        String validTargetAppt = NRIC_DESC_AMY
+                + DATE_DESC_APPOINTMENT_AMY
+                + START_TIME_DESC_APPOINTMENT_AMY
+                + END_TIME_DESC_APPOINTMENT_AMY;
+
+        String userInput = validTargetAppt + NEW_TYPE_DESC_APPOINTMENT_BOB + NEW_NOTE_DESC_APPOINTMENT_AMY;
+
+        EditApptCommand.EditApptDescriptor descriptor =
+                new EditApptDescriptorBuilder().withAppointmentType(VALID_APPOINTMENT_TYPE_BOB)
+                        .withNote(VALID_APPOINTMENT_NOTE_AMY).build();
+        EditApptCommand expectedCommand = new EditApptCommand(targetNric, targetDate, targetTimePeriod, descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
     }
 
     @Test
     public void parse_oneFieldSpecified_success() {
-        // name
-        Nric targetNric = new Nric(VALID_NRIC_BOB);
-        String userInput = targetNric + NAME_DESC_AMY;
-        EditPatientDescriptor descriptor = new EditPatientDescriptorBuilder().withName(VALID_NAME_AMY).build();
-        EditPatientCommand expectedCommand = new EditPatientCommand(targetNric, descriptor);
+        Nric targetNric = new Nric(VALID_NRIC_AMY);
+        Date targetDate = new Date(VALID_APPOINTMENT_DATE_AMY);
+        TimePeriod targetTimePeriod = new TimePeriod(
+                new Time(VALID_APPOINTMENT_START_TIME_AMY),
+                new Time(VALID_APPOINTMENT_END_TIME_AMY)
+        );
+
+        String validTargetAppt = NRIC_DESC_AMY
+                + DATE_DESC_APPOINTMENT_AMY
+                + START_TIME_DESC_APPOINTMENT_AMY
+                + END_TIME_DESC_APPOINTMENT_AMY;
+
+        String userInput = validTargetAppt + NEW_NOTE_DESC_APPOINTMENT_BOB;
+        EditApptDescriptor descriptor = new EditApptDescriptorBuilder().withNote(VALID_APPOINTMENT_NOTE_BOB).build();
+        EditApptCommand expectedCommand = new EditApptCommand(targetNric, targetDate, targetTimePeriod, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
-        // dob
-        userInput = targetNric + DOB_DESC_AMY;
-        descriptor = new EditPatientDescriptorBuilder().withDateOfBirth(VALID_DOB_AMY).build();
-        expectedCommand = new EditPatientCommand(targetNric, descriptor);
+        // date
+        userInput = validTargetAppt + NEW_DATE_DESC_APPOINTMENT_BOB;
+        descriptor = new EditApptDescriptorBuilder().withDate(VALID_APPOINTMENT_DATE_BOB).build();
+        expectedCommand = new EditApptCommand(targetNric, targetDate, targetTimePeriod, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
-        // phone
-        userInput = targetNric + PHONE_DESC_AMY;
-        descriptor = new EditPatientDescriptorBuilder().withPhone(VALID_PHONE_AMY).build();
-        expectedCommand = new EditPatientCommand(targetNric, descriptor);
+        // startTime
+        userInput = validTargetAppt + NEW_START_TIME_DESC_APPOINTMENT_AMY;
+        descriptor = new EditApptDescriptorBuilder().withTimePeriod(VALID_APPOINTMENT_START_TIME_AMY, VALID_APPOINTMENT_END_TIME_AMY).build();
+        expectedCommand = new EditApptCommand(targetNric, targetDate, targetTimePeriod, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
-        // email
-        userInput = targetNric + EMAIL_DESC_AMY;
-        descriptor = new EditPatientDescriptorBuilder().withEmail(VALID_EMAIL_AMY).build();
-        expectedCommand = new EditPatientCommand(targetNric, descriptor);
+        //endTime
+        userInput = validTargetAppt + NEW_END_TIME_DESC_APPOINTMENT_AMY;
+        descriptor = new EditApptDescriptorBuilder().withTimePeriod(VALID_APPOINTMENT_START_TIME_AMY, VALID_APPOINTMENT_END_TIME_AMY).build();
+        expectedCommand = new EditApptCommand(targetNric, targetDate, targetTimePeriod, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
-        // address
-        userInput = targetNric + ADDRESS_DESC_AMY;
-        descriptor = new EditPatientDescriptorBuilder().withAddress(VALID_ADDRESS_AMY).build();
-        expectedCommand = new EditPatientCommand(targetNric, descriptor);
+        //appointmentType
+        userInput = validTargetAppt + NEW_TYPE_DESC_APPOINTMENT_BOB;
+        descriptor = new EditApptDescriptorBuilder().withAppointmentType(VALID_APPOINTMENT_TYPE_BOB).build();
+        expectedCommand = new EditApptCommand(targetNric, targetDate, targetTimePeriod, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
-        // tags
-        userInput = targetNric + TAG_DESC_FRIEND;
-        descriptor = new EditPatientDescriptorBuilder().withTags(VALID_TAG_FRIEND).build();
-        expectedCommand = new EditPatientCommand(targetNric, descriptor);
+        //note
+        userInput = validTargetAppt + NEW_NOTE_DESC_APPOINTMENT_BOB;
+        descriptor = new EditApptDescriptorBuilder().withNote(VALID_APPOINTMENT_NOTE_BOB).build();
+        expectedCommand = new EditApptCommand(targetNric, targetDate, targetTimePeriod, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
     }
 
@@ -221,41 +272,42 @@ public class EditApptCommandParserTest {
         // More extensive testing of duplicate parameter detections is done in
         // AddCommandParserTest#parse_repeatedNonTagValue_failure()
 
-        // invalid followed by valid
-        Nric targetNric = new Nric(VALID_NRIC_BOB);
-        String userInput = targetNric + INVALID_PHONE_DESC + PHONE_DESC_BOB;
+        String validTargetAppt = NRIC_DESC_AMY
+                + DATE_DESC_APPOINTMENT_AMY
+                + START_TIME_DESC_APPOINTMENT_AMY
+                + END_TIME_DESC_APPOINTMENT_AMY;
 
-        assertParseFailure(parser, userInput, Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE));
+        Nric targetNric = new Nric(VALID_NRIC_AMY);
+        Date targetDate = new Date(VALID_APPOINTMENT_DATE_AMY);
+        TimePeriod targetTimePeriod = new TimePeriod(
+                new Time(VALID_APPOINTMENT_START_TIME_AMY),
+                new Time(VALID_APPOINTMENT_END_TIME_AMY)
+        );
+
+        // invalid followed by valid
+        String userInput = validTargetAppt + INVALID_NEW_DATE_DESC + NEW_DATE_DESC_APPOINTMENT_AMY;
+        assertParseFailure(parser, userInput, Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NEW_DATE));
 
         // valid followed by invalid
-        userInput = targetNric + PHONE_DESC_BOB + INVALID_PHONE_DESC;
-
-        assertParseFailure(parser, userInput, Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE));
+        userInput = validTargetAppt + NEW_DATE_DESC_APPOINTMENT_AMY + INVALID_NEW_DATE_DESC;
+        assertParseFailure(parser, userInput, Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NEW_DATE));
 
         // multiple valid fields repeated
-        userInput = targetNric + PHONE_DESC_AMY + ADDRESS_DESC_AMY + EMAIL_DESC_AMY
-                + TAG_DESC_FRIEND + PHONE_DESC_AMY + ADDRESS_DESC_AMY + EMAIL_DESC_AMY + TAG_DESC_FRIEND
-                + PHONE_DESC_BOB + ADDRESS_DESC_BOB + EMAIL_DESC_BOB + TAG_DESC_HUSBAND;
+        userInput = validTargetAppt + NEW_DATE_DESC_APPOINTMENT_AMY + NEW_START_TIME_DESC_APPOINTMENT_AMY
+                + NEW_END_TIME_DESC_APPOINTMENT_AMY
+                + NEW_TYPE_DESC_APPOINTMENT_AMY
+                + NEW_DATE_DESC_APPOINTMENT_AMY + NEW_START_TIME_DESC_APPOINTMENT_AMY
+                + NEW_END_TIME_DESC_APPOINTMENT_AMY + NEW_TYPE_DESC_APPOINTMENT_AMY;
 
         assertParseFailure(parser, userInput,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS));
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NEW_DATE,
+                        PREFIX_NEW_START_TIME, PREFIX_NEW_END_TIME, PREFIX_NEW_TAG));
 
         // multiple invalid values
-        userInput = targetNric + INVALID_PHONE_DESC + INVALID_ADDRESS_DESC + INVALID_EMAIL_DESC
-                + INVALID_PHONE_DESC + INVALID_ADDRESS_DESC + INVALID_EMAIL_DESC;
+        userInput = validTargetAppt + INVALID_NEW_DATE_DESC + INVALID_NEW_END_TIME_DESC + INVALID_NEW_APPOINTMENT_TYPE_DESC
+                + INVALID_NEW_DATE_DESC + INVALID_NEW_END_TIME_DESC + INVALID_NEW_APPOINTMENT_TYPE_DESC;
 
         assertParseFailure(parser, userInput,
-                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS));
-    }
-
-    @Test
-    public void parse_resetTags_success() {
-        Nric targetNric = new Nric(VALID_NRIC_BOB);
-        String userInput = targetNric + TAG_EMPTY;
-
-        EditPatientDescriptor descriptor = new EditPatientDescriptorBuilder().withTags().build();
-        EditPatientCommand expectedCommand = new EditPatientCommand(targetNric, descriptor);
-
-        assertParseSuccess(parser, userInput, expectedCommand);
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NEW_DATE, PREFIX_NEW_END_TIME, PREFIX_NEW_TAG));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/EditApptCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditApptCommandParserTest.java
@@ -145,13 +145,13 @@ public class EditApptCommandParserTest {
 
         //More invalid tests here for the descriptors
         assertParseFailure(parser, validTargetAppt
-         + INVALID_NEW_DATE_DESC , Date.MESSAGE_CONSTRAINTS); // invalid new date
+                + INVALID_NEW_DATE_DESC , Date.MESSAGE_CONSTRAINTS); // invalid new date
         assertParseFailure(parser, validTargetAppt
                 + INVALID_NEW_START_TIME_DESC , TimePeriod.MESSAGE_CONSTRAINTS); // invalid new startTime
         assertParseFailure(parser, validTargetAppt
                 + INVALID_NEW_END_TIME_DESC , TimePeriod.MESSAGE_CONSTRAINTS); // invalid new endTime
         assertParseFailure(parser, validTargetAppt
-                + INVALID_NEW_APPOINTMENT_TYPE_DESC , AppointmentType.MESSAGE_CONSTRAINTS); // invalid new appointmentType
+                + INVALID_NEW_APPOINTMENT_TYPE_DESC , AppointmentType.MESSAGE_CONSTRAINTS); // invalid new apptType
 
         //all notes are valid so no test for that
 
@@ -244,13 +244,15 @@ public class EditApptCommandParserTest {
 
         // startTime
         userInput = validTargetAppt + NEW_START_TIME_DESC_APPOINTMENT_AMY;
-        descriptor = new EditApptDescriptorBuilder().withTimePeriod(VALID_APPOINTMENT_START_TIME_AMY, VALID_APPOINTMENT_END_TIME_AMY).build();
+        descriptor = new EditApptDescriptorBuilder().withTimePeriod(VALID_APPOINTMENT_START_TIME_AMY,
+                VALID_APPOINTMENT_END_TIME_AMY).build();
         expectedCommand = new EditApptCommand(targetNric, targetDate, targetTimePeriod, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         //endTime
         userInput = validTargetAppt + NEW_END_TIME_DESC_APPOINTMENT_AMY;
-        descriptor = new EditApptDescriptorBuilder().withTimePeriod(VALID_APPOINTMENT_START_TIME_AMY, VALID_APPOINTMENT_END_TIME_AMY).build();
+        descriptor = new EditApptDescriptorBuilder().withTimePeriod(VALID_APPOINTMENT_START_TIME_AMY,
+                VALID_APPOINTMENT_END_TIME_AMY).build();
         expectedCommand = new EditApptCommand(targetNric, targetDate, targetTimePeriod, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
@@ -304,7 +306,8 @@ public class EditApptCommandParserTest {
                         PREFIX_NEW_START_TIME, PREFIX_NEW_END_TIME, PREFIX_NEW_TAG));
 
         // multiple invalid values
-        userInput = validTargetAppt + INVALID_NEW_DATE_DESC + INVALID_NEW_END_TIME_DESC + INVALID_NEW_APPOINTMENT_TYPE_DESC
+        userInput = validTargetAppt + INVALID_NEW_DATE_DESC
+                + INVALID_NEW_END_TIME_DESC + INVALID_NEW_APPOINTMENT_TYPE_DESC
                 + INVALID_NEW_DATE_DESC + INVALID_NEW_END_TIME_DESC + INVALID_NEW_APPOINTMENT_TYPE_DESC;
 
         assertParseFailure(parser, userInput,

--- a/src/test/java/seedu/address/logic/parser/EditApptCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditApptCommandParserTest.java
@@ -1,0 +1,261 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.DATE_DESC_APPOINTMENT_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.DESC_APPT_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.DOB_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.END_TIME_DESC_APPOINTMENT_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.END_TIME_DESC_APPOINTMENT_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_ADDRESS_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_DATE_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_DOB_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.NRIC_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.START_TIME_DESC_APPOINTMENT_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
+import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_APPOINTMENT_DATE_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_APPOINTMENT_END_TIME_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_APPOINTMENT_START_TIME_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_DOB_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NRIC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NRIC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.date.Date;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.EditApptCommand;
+import seedu.address.logic.commands.EditPatientCommand;
+import seedu.address.logic.commands.EditPatientCommand.EditPatientDescriptor;
+import seedu.address.model.appointment.Time;
+import seedu.address.model.patient.Address;
+import seedu.address.model.patient.DateOfBirth;
+import seedu.address.model.patient.Email;
+import seedu.address.model.patient.Name;
+import seedu.address.model.patient.Nric;
+import seedu.address.model.patient.Phone;
+import seedu.address.model.tag.Tag;
+import seedu.address.testutil.EditPatientDescriptorBuilder;
+
+public class EditApptCommandParserTest {
+
+    private static final String TAG_EMPTY = " " + PREFIX_TAG;
+
+    private static final String MESSAGE_INVALID_FORMAT =
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditApptCommand.MESSAGE_USAGE);
+
+    private EditApptCommandParser parser = new EditApptCommandParser();
+
+    @Test
+    public void parse_missingParts_failure() {
+        // no nric specified
+        assertParseFailure(parser, DATE_DESC_APPOINTMENT_AMY
+                + START_TIME_DESC_APPOINTMENT_AMY
+                + END_TIME_DESC_APPOINTMENT_AMY
+                + DESC_APPT_AMY, MESSAGE_INVALID_FORMAT);
+
+        // no date specified
+        assertParseFailure(parser, NRIC_DESC_AMY
+                + START_TIME_DESC_APPOINTMENT_AMY
+                + END_TIME_DESC_APPOINTMENT_AMY
+                + DESC_APPT_AMY, MESSAGE_INVALID_FORMAT);
+
+        // no startTime specified
+        assertParseFailure(parser, NRIC_DESC_AMY
+                + DATE_DESC_APPOINTMENT_AMY
+                + END_TIME_DESC_APPOINTMENT_AMY
+                + DESC_APPT_AMY, MESSAGE_INVALID_FORMAT);
+
+        // no endTime specified
+        assertParseFailure(parser, NRIC_DESC_AMY
+                + DATE_DESC_APPOINTMENT_AMY
+                + START_TIME_DESC_APPOINTMENT_AMY
+                + DESC_APPT_AMY, MESSAGE_INVALID_FORMAT);
+
+        // no field specified
+        assertParseFailure(
+                parser,
+                NRIC_DESC_AMY
+                + DATE_DESC_APPOINTMENT_AMY
+                + START_TIME_DESC_APPOINTMENT_AMY
+                + END_TIME_DESC_APPOINTMENT_AMY,
+                EditApptCommand.MESSAGE_EDIT_APPT_NO_FIELDS_FAILURE);
+
+        // no nric, date, startTime, endTime and fields specified
+        assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_invalidPreamble_failure() {
+
+        // invalid arguments being parsed as preamble
+        assertParseFailure(parser, "some random string"
+                + NRIC_DESC_AMY
+                + DATE_DESC_APPOINTMENT_AMY
+                + START_TIME_DESC_APPOINTMENT_AMY
+                + END_TIME_DESC_APPOINTMENT_AMY
+                + DESC_APPT_AMY, MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_invalidValue_failure() {
+        assertParseFailure(parser, NRIC_DESC_AMY
+                + INVALID_DATE_DESC, Date.MESSAGE_CONSTRAINTS); // invalid date
+        assertParseFailure(parser, VALID_NRIC_AMY + INVALID_DOB_DESC, Time.MESSAGE_CONSTRAINTS); // invalid startTime
+        assertParseFailure(parser, VALID_NRIC_AMY + INVALID_PHONE_DESC, Time.MESSAGE_CONSTRAINTS); // invalid endTime
+        assertParseFailure(parser, VALID_NRIC_AMY + INVALID_EMAIL_DESC, Email.MESSAGE_CONSTRAINTS); // invalid new date
+        assertParseFailure(parser, VALID_NRIC_AMY
+                + INVALID_ADDRESS_DESC, Address.MESSAGE_CONSTRAINTS); // invalid address
+        assertParseFailure(parser, VALID_NRIC_AMY + INVALID_TAG_DESC, Tag.MESSAGE_CONSTRAINTS); // invalid tag
+
+        // invalid phone followed by valid email
+        assertParseFailure(parser, VALID_NRIC_AMY + INVALID_PHONE_DESC + EMAIL_DESC_AMY, Phone.MESSAGE_CONSTRAINTS);
+
+        // while parsing {@code PREFIX_TAG} alone will reset the tags of the {@code Patient} being edited,
+        // parsing it together with a valid tag results in error
+        assertParseFailure(parser, VALID_NRIC_AMY + TAG_DESC_FRIEND
+                + TAG_DESC_HUSBAND + TAG_EMPTY, Tag.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, VALID_NRIC_AMY + TAG_DESC_FRIEND
+                + TAG_EMPTY + TAG_DESC_HUSBAND, Tag.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, VALID_NRIC_AMY + TAG_EMPTY + TAG_DESC_FRIEND
+                + TAG_DESC_HUSBAND, Tag.MESSAGE_CONSTRAINTS);
+
+        // multiple invalid values, but only the first invalid value is captured
+        assertParseFailure(parser, VALID_NRIC_AMY + INVALID_NAME_DESC + INVALID_EMAIL_DESC
+                + VALID_ADDRESS_AMY + VALID_PHONE_AMY, Name.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_allFieldsSpecified_success() {
+        Nric targetNric = new Nric(VALID_NRIC_AMY);
+        String userInput = targetNric + PHONE_DESC_BOB + TAG_DESC_HUSBAND
+                + DOB_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + NAME_DESC_AMY + TAG_DESC_FRIEND;
+
+        EditPatientDescriptor descriptor = new EditPatientDescriptorBuilder().withName(VALID_NAME_AMY)
+                .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY)
+                .withDateOfBirth(VALID_DOB_AMY).withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
+        EditPatientCommand expectedCommand = new EditPatientCommand(targetNric, descriptor);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_someFieldsSpecified_success() {
+        Nric targetNric = new Nric(VALID_NRIC_AMY);
+        String userInput = targetNric + PHONE_DESC_BOB + EMAIL_DESC_AMY;
+
+        EditPatientCommand.EditPatientDescriptor descriptor =
+                new EditPatientDescriptorBuilder().withPhone(VALID_PHONE_BOB)
+                        .withEmail(VALID_EMAIL_AMY).build();
+        EditPatientCommand expectedCommand = new EditPatientCommand(targetNric, descriptor);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_oneFieldSpecified_success() {
+        // name
+        Nric targetNric = new Nric(VALID_NRIC_BOB);
+        String userInput = targetNric + NAME_DESC_AMY;
+        EditPatientDescriptor descriptor = new EditPatientDescriptorBuilder().withName(VALID_NAME_AMY).build();
+        EditPatientCommand expectedCommand = new EditPatientCommand(targetNric, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+
+        // dob
+        userInput = targetNric + DOB_DESC_AMY;
+        descriptor = new EditPatientDescriptorBuilder().withDateOfBirth(VALID_DOB_AMY).build();
+        expectedCommand = new EditPatientCommand(targetNric, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+
+        // phone
+        userInput = targetNric + PHONE_DESC_AMY;
+        descriptor = new EditPatientDescriptorBuilder().withPhone(VALID_PHONE_AMY).build();
+        expectedCommand = new EditPatientCommand(targetNric, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+
+        // email
+        userInput = targetNric + EMAIL_DESC_AMY;
+        descriptor = new EditPatientDescriptorBuilder().withEmail(VALID_EMAIL_AMY).build();
+        expectedCommand = new EditPatientCommand(targetNric, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+
+        // address
+        userInput = targetNric + ADDRESS_DESC_AMY;
+        descriptor = new EditPatientDescriptorBuilder().withAddress(VALID_ADDRESS_AMY).build();
+        expectedCommand = new EditPatientCommand(targetNric, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+
+        // tags
+        userInput = targetNric + TAG_DESC_FRIEND;
+        descriptor = new EditPatientDescriptorBuilder().withTags(VALID_TAG_FRIEND).build();
+        expectedCommand = new EditPatientCommand(targetNric, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_multipleRepeatedFields_failure() {
+        // More extensive testing of duplicate parameter detections is done in
+        // AddCommandParserTest#parse_repeatedNonTagValue_failure()
+
+        // invalid followed by valid
+        Nric targetNric = new Nric(VALID_NRIC_BOB);
+        String userInput = targetNric + INVALID_PHONE_DESC + PHONE_DESC_BOB;
+
+        assertParseFailure(parser, userInput, Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE));
+
+        // valid followed by invalid
+        userInput = targetNric + PHONE_DESC_BOB + INVALID_PHONE_DESC;
+
+        assertParseFailure(parser, userInput, Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE));
+
+        // multiple valid fields repeated
+        userInput = targetNric + PHONE_DESC_AMY + ADDRESS_DESC_AMY + EMAIL_DESC_AMY
+                + TAG_DESC_FRIEND + PHONE_DESC_AMY + ADDRESS_DESC_AMY + EMAIL_DESC_AMY + TAG_DESC_FRIEND
+                + PHONE_DESC_BOB + ADDRESS_DESC_BOB + EMAIL_DESC_BOB + TAG_DESC_HUSBAND;
+
+        assertParseFailure(parser, userInput,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS));
+
+        // multiple invalid values
+        userInput = targetNric + INVALID_PHONE_DESC + INVALID_ADDRESS_DESC + INVALID_EMAIL_DESC
+                + INVALID_PHONE_DESC + INVALID_ADDRESS_DESC + INVALID_EMAIL_DESC;
+
+        assertParseFailure(parser, userInput,
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS));
+    }
+
+    @Test
+    public void parse_resetTags_success() {
+        Nric targetNric = new Nric(VALID_NRIC_BOB);
+        String userInput = targetNric + TAG_EMPTY;
+
+        EditPatientDescriptor descriptor = new EditPatientDescriptorBuilder().withTags().build();
+        EditPatientCommand expectedCommand = new EditPatientCommand(targetNric, descriptor);
+
+        assertParseSuccess(parser, userInput, expectedCommand);
+    }
+}

--- a/src/test/java/seedu/address/testutil/AppointmentUtil.java
+++ b/src/test/java/seedu/address/testutil/AppointmentUtil.java
@@ -2,12 +2,19 @@ package seedu.address.testutil;
 
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_END_TIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NEW_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NEW_END_TIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NEW_NOTE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NEW_START_TIME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NEW_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NOTE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_START_TIME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import seedu.address.logic.commands.AddApptCommand;
+import seedu.address.logic.commands.DeleteApptCommand;
+import seedu.address.logic.commands.EditApptCommand;
 import seedu.address.model.appointment.Appointment;
 
 /**
@@ -18,8 +25,15 @@ public class AppointmentUtil {
     /**
      * Returns an addApp command string for adding the {@code appointment}.
      */
-    public static String getAddAppCommand(Appointment appointment) {
+    public static String getAddApptCommand(Appointment appointment) {
         return AddApptCommand.COMMAND_WORD + " " + getAppointmentDetails(appointment);
+    }
+
+    /**
+     * Returns a deleteApp command string for deleting the {@code appointment}.
+     */
+    public static String getDeleteApptCommand(Appointment appointment) {
+        return DeleteApptCommand.COMMAND_WORD + " " + getAppointmentUniqueDetails(appointment);
     }
 
     /**
@@ -33,6 +47,34 @@ public class AppointmentUtil {
         sb.append(PREFIX_END_TIME + appointment.getEndTime().toString() + " ");
         sb.append(PREFIX_TAG + appointment.getAppointmentType().typeName + " ");
         sb.append(PREFIX_NOTE + appointment.getNote().note + " ");
+        return sb.toString();
+    }
+
+    /**
+     * Returns the part of command string that uniquely identifies the given {@code appointment}.
+     */
+    public static String getAppointmentUniqueDetails(Appointment appointment) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(PREFIX_NRIC + appointment.getNric().value + " ");
+        sb.append(PREFIX_DATE + appointment.getDate().toString() + " ");
+        sb.append(PREFIX_START_TIME + appointment.getStartTime().toString() + " ");
+        sb.append(PREFIX_END_TIME + appointment.getEndTime().toString() + " ");
+        return sb.toString();
+    }
+
+    /**
+     * Returns the part of command string for the given {@code EditApptDescriptor}'s details.
+     */
+    public static String getEditApptDescriptorDetails(EditApptCommand.EditApptDescriptor descriptor) {
+        StringBuilder sb = new StringBuilder();
+        descriptor.getDate().ifPresent(date -> sb.append(PREFIX_NEW_DATE).append(date.value).append(" "));
+        descriptor.getTimePeriod().ifPresent(timePeriod -> {
+            sb.append(PREFIX_NEW_START_TIME).append(timePeriod.getStartTime().value).append(" ");
+            sb.append(PREFIX_NEW_END_TIME).append(timePeriod.getEndTime().value).append(" ");
+        });
+        descriptor.getAppointmentType().ifPresent(appointmentType -> sb.append(PREFIX_NEW_TAG)
+                .append(appointmentType.typeName).append(" "));
+        descriptor.getNote().ifPresent(note -> sb.append(PREFIX_NEW_NOTE).append(note).append(" "));
         return sb.toString();
     }
 }

--- a/src/test/java/seedu/address/testutil/EditApptDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditApptDescriptorBuilder.java
@@ -1,0 +1,71 @@
+package seedu.address.testutil;
+
+import seedu.address.commons.core.date.Date;
+import seedu.address.logic.commands.EditApptCommand.EditApptDescriptor;
+import seedu.address.model.appointment.Appointment;
+import seedu.address.model.appointment.AppointmentType;
+import seedu.address.model.appointment.Note;
+import seedu.address.model.appointment.Time;
+import seedu.address.model.appointment.TimePeriod;
+
+/**
+ * A utility class to help with building EditApptDescriptor objects.
+ */
+public class EditApptDescriptorBuilder {
+
+    private EditApptDescriptor descriptor;
+
+    public EditApptDescriptorBuilder() {
+        descriptor = new EditApptDescriptor();
+    }
+
+    public EditApptDescriptorBuilder(EditApptDescriptor descriptor) {
+        this.descriptor = new EditApptDescriptor(descriptor);
+    }
+
+    /**
+     * Returns an {@code EditApptDescriptor} with fields containing {@code appointment}'s details
+     */
+    public EditApptDescriptorBuilder(Appointment appointment) {
+        descriptor = new EditApptDescriptor();
+        descriptor.setDate(appointment.getDate());
+        descriptor.setTimePeriod(appointment.getTimePeriod());
+        descriptor.setAppointmentType(appointment.getAppointmentType());
+        descriptor.setNote(appointment.getNote());
+    }
+
+    /**
+     * Sets the {@code Date} of the {@code EditApptDescriptor} that we are building.
+     */
+    public EditApptDescriptorBuilder withDate(String date) {
+        descriptor.setDate(new Date(date));
+        return this;
+    }
+
+    /**
+     * Sets the {@code TimePeriod} of the {@code EditApptDescriptor} that we are building.
+     */
+    public EditApptDescriptorBuilder withTimePeriod(String startTime, String endTime) {
+        descriptor.setTimePeriod(new TimePeriod(new Time(startTime), new Time(endTime)));
+        return this;
+    }
+
+    /**
+     * Sets the {@code AppointmentType} of the {@code EditApptDescriptor} that we are building.
+     */
+    public EditApptDescriptorBuilder withAppointmentType(String appointmentType) {
+        descriptor.setAppointmentType(new AppointmentType(appointmentType));
+        return this;
+    }
+
+    /**
+     * Sets the {@code Note} of the {@code EditApptDescriptor} that we are building.
+     */
+    public EditApptDescriptorBuilder withNote(String note) {
+        descriptor.setNote(new Note(note));
+        return this;
+    }
+    public EditApptDescriptor build() {
+        return descriptor;
+    }
+}


### PR DESCRIPTION
Add EditApptCommand that takes in NRIC, Date, StartTime and EndTime to find the appointment to be edited. User can edit Date, StartTime, EndTime, AppointmentType and Note for that particular appointment. 

This version does not yet take into account the duplicate appointments, will work on flagging that in the future. 

The prefixes for the new information start with 'new' and the original prefix. E.g. "newd", "newnote" etc. Updated User Guide with this.

Also refactored some of the test names in AddressBookParserTest to fit Patient and Appt.