### PR TITLE
Fix name field of edited patient to show up in AppointmentView

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditApptCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditApptCommand.java
@@ -108,7 +108,7 @@ public class EditApptCommand extends Command {
 
         Appointment editedAppt = createEditedAppointment(apptToEdit, editApptDescriptor);
         model.setAppointment(apptToEdit, editedAppt);
-        model.updateFilteredAppointmentList(PREDICATE_SHOW_ALL_APPOINTMENT_VIEWS);
+        model.updateFilteredAppointmentViewList(PREDICATE_SHOW_ALL_APPOINTMENT_VIEWS);
         return new CommandResult(String.format(MESSAGE_EDIT_APPT_SUCCESS, Messages.format(editedAppt)));
     }
 

--- a/src/main/java/seedu/address/logic/commands/FindApptCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindApptCommand.java
@@ -48,7 +48,7 @@ public class FindApptCommand extends Command {
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.updateFilteredAppointmentList(predicate);
+        model.updateFilteredAppointmentViewList(predicate);
         return new CommandResult(
                 String.format(Messages.MESSAGE_APPOINTMENTS_LISTED_OVERVIEW,
                         model.getFilteredAppointmentViewList().size()), ViewMode.OVERALL);

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -21,7 +21,7 @@ public class ListCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.updateFilteredPatientList(PREDICATE_SHOW_ALL_PATIENTS);
-        model.updateFilteredAppointmentList(PREDICATE_SHOW_ALL_APPOINTMENT_VIEWS);
+        model.updateFilteredAppointmentViewList(PREDICATE_SHOW_ALL_APPOINTMENT_VIEWS);
         return new CommandResult(MESSAGE_LIST_SUCCESS, ViewMode.OVERALL);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/MarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkCommand.java
@@ -75,7 +75,7 @@ public class MarkCommand extends Command {
 
         Appointment markedAppt = createMarkedAppointment(apptToMark);
         model.setAppointment(apptToMark, markedAppt);
-        model.updateFilteredAppointmentList(PREDICATE_SHOW_ALL_APPOINTMENT_VIEWS);
+        model.updateFilteredAppointmentViewList(PREDICATE_SHOW_ALL_APPOINTMENT_VIEWS);
         return new CommandResult(String.format(MESSAGE_MARK_APPOINTMENT_SUCCESS, Messages.format(markedAppt)));
     }
 

--- a/src/main/java/seedu/address/logic/commands/UnmarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnmarkCommand.java
@@ -76,7 +76,7 @@ public class UnmarkCommand extends Command {
 
         Appointment unmarkedAppt = createUnmarkedAppointment(apptToUnmark);
         model.setAppointment(apptToUnmark, unmarkedAppt);
-        model.updateFilteredAppointmentList(PREDICATE_SHOW_ALL_APPOINTMENT_VIEWS);
+        model.updateFilteredAppointmentViewList(PREDICATE_SHOW_ALL_APPOINTMENT_VIEWS);
         return new CommandResult(String.format(MESSAGE_UNMARK_APPOINTMENT_SUCCESS, Messages.format(unmarkedAppt)));
     }
 

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -123,6 +123,7 @@ public class AddressBook implements ReadOnlyAddressBook {
         requireNonNull(editedPatient);
 
         patients.setPatient(target, editedPatient);
+        this.appointmentView.setAppointmentViews(patients, appointments);
     }
 
     /**

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -136,11 +136,11 @@ public interface Model {
     ObservableList<AppointmentView> getFilteredAppointmentViewList();
 
     /**
-     * Updates the filter of the filtered appointment list to filter by the given {@code predicate}.
+     * Updates the filter of the filtered appointment view list to filter by the given {@code predicate}.
      * @throws NullPointerException if {@code predicate} is null.
      */
 
-    void updateFilteredAppointmentList(Predicate<AppointmentView> predicate);
+    void updateFilteredAppointmentViewList(Predicate<AppointmentView> predicate);
 
     /** Returns an unmodifiable view of the appointment day-view list */
     ObservableList<AppointmentView> getFilteredAppointmentDayViewList();

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -156,7 +156,7 @@ public class ModelManager implements Model {
     @Override
     public void addAppointment(Appointment appointment) {
         addressBook.addAppointment(appointment);
-        updateFilteredAppointmentList(PREDICATE_SHOW_ALL_APPOINTMENT_VIEWS);
+        updateFilteredAppointmentViewList(PREDICATE_SHOW_ALL_APPOINTMENT_VIEWS);
     }
 
     @Override
@@ -206,7 +206,7 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public void updateFilteredAppointmentList(Predicate<AppointmentView> predicate) {
+    public void updateFilteredAppointmentViewList(Predicate<AppointmentView> predicate) {
         requireNonNull(predicate);
         filteredAppointmentsView.setPredicate(predicate);
     }

--- a/src/test/java/seedu/address/logic/commands/AddApptCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddApptCommandTest.java
@@ -218,7 +218,7 @@ public class AddApptCommandTest {
         }
 
         @Override
-        public void updateFilteredAppointmentList(Predicate<AppointmentView> predicate) {
+        public void updateFilteredAppointmentViewList(Predicate<AppointmentView> predicate) {
         }
 
         @Override

--- a/src/test/java/seedu/address/logic/commands/AddPatientCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddPatientCommandTest.java
@@ -201,7 +201,7 @@ public class AddPatientCommandTest {
         }
 
         @Override
-        public void updateFilteredAppointmentList(Predicate<AppointmentView> predicate) {
+        public void updateFilteredAppointmentViewList(Predicate<AppointmentView> predicate) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/logic/commands/FindApptCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindApptCommandTest.java
@@ -89,7 +89,7 @@ public class FindApptCommandTest {
                 " i/T0123456A d/2024-03-01 from/16:00"
         );
         FindApptCommand command = new FindApptCommand(predicate);
-        expectedModel.updateFilteredAppointmentList(predicate);
+        expectedModel.updateFilteredAppointmentViewList(predicate);
         assertOverallCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Arrays.asList(ALICE_APPT_VIEW), model.getFilteredAppointmentViewList());
     }
@@ -101,7 +101,7 @@ public class FindApptCommandTest {
                 " i/T0123456A"
         );
         FindApptCommand command = new FindApptCommand(predicate);
-        expectedModel.updateFilteredAppointmentList(predicate);
+        expectedModel.updateFilteredAppointmentViewList(predicate);
         assertOverallCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Arrays.asList(ALICE_APPT_VIEW, ALICE_APPT_VIEW_1),
                 model.getFilteredAppointmentViewList());
@@ -114,7 +114,7 @@ public class FindApptCommandTest {
                 " i/T0123456A from/16:00"
         );
         FindApptCommand command = new FindApptCommand(predicate);
-        expectedModel.updateFilteredAppointmentList(predicate);
+        expectedModel.updateFilteredAppointmentViewList(predicate);
         assertOverallCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Arrays.asList(ALICE_APPT_VIEW, ALICE_APPT_VIEW_1),
                 model.getFilteredAppointmentViewList());
@@ -127,7 +127,7 @@ public class FindApptCommandTest {
                 " i/T6543210A"
         );
         FindApptCommand command = new FindApptCommand(predicate);
-        expectedModel.updateFilteredAppointmentList(predicate);
+        expectedModel.updateFilteredAppointmentViewList(predicate);
         assertOverallCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Arrays.asList(), model.getFilteredAppointmentViewList());
     }


### PR DESCRIPTION
Added line to `AddressBook#setPatient to update the `AppointmentViewList` when patient has been edited.
Refactored `updateFilteredAppointmentList` to `updateFilteredAppointmentViewList`.