### PR TITLE
Change delete, edit, mark and unmark appt to no longer require endTime and update UG 

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -187,34 +187,35 @@ Examples:
 
 Deleting an appointment from CLInic.
 
-Format: `deleteAppt i/NRIC d/DATE from/START_TIME to/END_TIME` <br/>
-Shorthand: `da i/NRIC d/DATE from/START_TIME to/END_TIME`
+Format: `deleteAppt i/NRIC d/DATE from/START_TIME` <br/>
+Shorthand: `da i/NRIC d/DATE from/START_TIME`
 
-* Deletes an appointment for the patient with specified `NRIC`, on `DATE` from `START_TIME` to `END_TIME`
+* Deletes an appointment for the patient with specified `NRIC`, on `DATE` from `START_TIME`.
 * Appointment with the stated details **must exist within database**.
+* `END_TIME` not needed as same patient can never have overlapping appointments, hence `START_TIME` is unique 
 
 Examples:
-* `deleteAppt i/ S8743880A d/ 2024-02-20 from/ 11:00 to/ 11:30`
-* `da i/ S8743880A d/ 2024-02-20 from/ 11:00 to/ 11:30`
+* `deleteAppt i/ S8743880A d/ 2024-02-20 from/ 11:00`
+* `da i/ S8743880A d/ 2024-02-20 from/ 11:00`
 
 ### Editing an Appointment : `editAppointment` OR `ea`
 
 Edits an existing appointment in CLInic.
 
-Format: `editAppt i/NRIC d/DATE from/START_TIME to/END_TIME [newd/NEW_DATE] [newfrom/NEW_START_TIME] [newto/NEW_END_TIME] [newt/NEW_APPOINTMENT_TYPE] [newnote/NEW_NOTE]` <br/>
-Shorthand: `ea i/NRIC d/DATE from/START_TIME to/END_TIME [newd/NEW_DATE] [newfrom/NEW_START_TIME] [newto/NEW_END_TIME] [newt/NEW_APPOINTMENT_TYPE] [newnote/NEW_NOTE]`
+Format: `editAppt i/NRIC d/DATE from/START_TIME [newd/NEW_DATE] [newfrom/NEW_START_TIME] [newto/NEW_END_TIME] [newt/NEW_APPOINTMENT_TYPE] [newnote/NEW_NOTE]` <br/>
+Shorthand: `ea i/NRIC d/DATE from/START_TIME [newd/NEW_DATE] [newfrom/NEW_START_TIME] [newto/NEW_END_TIME] [newt/NEW_APPOINTMENT_TYPE] [newnote/NEW_NOTE]`
 
-* Edits the appointment with the specified NRIC, DATE, START_TIME and END_TIME.
+* Edits the appointment with the specified NRIC, DATE and START_TIME.
 * Ensure the NRIC is valid and exists in the system.
 * Provide at least one optional field for editing.
 * Existing values will be updated to the input values.
 
 Examples:
-*  `editAppt i/ T0123456A d/ 2024-02-20 from/ 11:00 to/ 11:30 newd/ 2024-02-21` 
-  * Edits the date of the appointment with NRIC:`T0123456A`, DATE: `2024-02-20`, START_TIME: `11:00`, END_TIME: `11:30` to be `2024-02-21` instead.
-*  `editAppt i/ S8743880A d/ 2024-10-20 from/ 14:00 to/ 16:30 newnote/ ` 
-  * Clears note for appointment with NRIC:`S8743880A`, DATE: `2024-10-20`, START_TIME: `14:00`, END_TIME: `16:30`.
-*  `ea i/ S8743880A d/ 2024-10-20 from/ 14:00 to/ 16:30 newnote/ `
+*  `editAppt i/ T0123456A d/ 2024-02-20 from/ 11:00 newd/ 2024-02-21` 
+  * Edits the date of the appointment with NRIC:`T0123456A`, DATE: `2024-02-20`, START_TIME: `11:00`, to be `2024-02-21` instead.
+*  `editAppt i/ S8743880A d/ 2024-10-20 from/ 14:00 newnote/ ` 
+  * Clears note for appointment with NRIC:`S8743880A`, DATE: `2024-10-20`, START_TIME: `14:00`.
+*  `ea i/ S8743880A d/ 2024-10-20 from/ 14:00 newnote/ `
 
 ### Finding appointments: `findAppt` OR `fa`
 
@@ -237,25 +238,27 @@ Examples:
 
 Marks an appointment from the address book.
 
-Format: `mark i/ NRIC d/ DATE /from START_TIME /to END_TIME`
+Format: `mark i/ NRIC d/ DATE /from START_TIME`
 
-* Marks an appointment for the patient with specified `NRIC`, on `DATE` from `START_TIME` to `END_TIME`
+* Marks an appointment for the patient with specified `NRIC`, on `DATE` from `START_TIME`
 * Appointment with the stated details **must exist within database**.
+* `END_TIME` not needed as same patient can never have overlapping appointments, hence `START_TIME` is unique
 
 Examples:
-* `mark i/ T0123456A d/ 2024-02-20 from/ 11:00 to/ 11:30`
+* `mark i/ T0123456A d/ 2024-02-20 from/ 11:00`
 
 ### Unmarking an Appointment: `unmark`
 
 Unmarks an appointment from the address book.
 
-Format: `unmark i/ NRIC d/ DATE /from START_TIME /to END_TIME`
+Format: `unmark i/ NRIC d/ DATE /from START_TIME`
 
-* Unmarks an appointment for the patient with specified `NRIC`, on `DATE` from `START_TIME` to `END_TIME`
+* Unmarks an appointment for the patient with specified `NRIC`, on `DATE` from `START_TIME`
 * Appointment with the stated details **must exist within database**.
+* `END_TIME` not needed as same patient can never have overlapping appointments, hence `START_TIME` is unique
 
 Examples:
-* `unmark i/ T0123456A d/ 2024-02-20 from/ 11:00 to/ 11:30`
+* `unmark i/ T0123456A d/ 2024-02-20 from/ 11:00`
 
 ### Listing all patients and appointments : `list` OR `ls`
 
@@ -329,20 +332,20 @@ _Details coming soon ..._
 --------------------------------------------------------------------------------------------------------------------
 
 ## Command summary
-| Action            | Format, Examples                                                                                                                                                                                                                                          |
-|-------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| **AddPatient**    | `addPatient i/NRIC n/NAME b/DOB p/PHONE_NUMBER e/EMAIL a/ADDRESS [t/TAG]…​` <br> e.g., `addPatient i/T0123456A n/John Doe b/2001-05-02 p/98765432 e/johnd@example.com a/John street, block 123, #01-01`                                                   |
-| **DeletePatient** | `deletePatient NRIC`<br> e.g., `deletePatient T0123456A`                                                                                                                                                                                                  |                                                                 |
-| **EditPatient**   | `editPatient NRIC [newn/NEW_NAME] [newp/NEW_PHONE_NUMBER] [newe/NEW_EMAIL] [newa/NEW_ADDRESS] [newt/NEW_TAG]…​`<br> e.g.,`editPatient T0123456A newn/James Lee newe/jameslee@example.com`                                                                 |
-| **FindPatient**   | `findPatient n/ KEYWORD [MORE_KEYWORDS]` OR `findPatient i/ KEYWORD`<br> e.g., `findPatient n/ James Jake`                                                                                                                                                |
-| **AddAppt**       | `addAppt i/NRIC d/DATE from/START_TIME to/END_TIME t/APPOINTMENT_TYPE note/NOTE`<br> e.g., `addAppt i/ T0123456A d/ 2024-02-20 from/ 11:00 to/ 11:30 t/ Medical Check-up note/ Routine check-in`                                                          |
-| **DeleteAppt**    | `deleteAppt i/NRIC d/DATE from/START_TIME to/END_TIME` <br> e.g., `deleteAppt i/ S8743880A d/ 2024-02-20 from/ 11:00 to/ 11:30`                                                                                                                           |
-| **EditAppt**      | `editAppt i/NRIC d/DATE from/START_TIME to/END_TIME [newd/NEW_DATE] [newfrom/NEW_START_TIME] [newto/NEW_END_TIME] [newt/NEW_APPOINTMENT_TYPE] [newnote/NEW_NOTE]` <br> e.g., `editAppt i/ T0123456A d/ 2024-02-20 from/ 11:00 to/ 11:30 newd/ 2024-02-21` |
-| **FindAppt**      | `findAppt [i/NRIC] [d/DATE] [from/START_TIME]` <br> e.g., `findAppt i/ T0123456A d/ 2024-02-20 from/ 11:00`                                                                                                                                               |
-| **Mark**          | `mark i/NRIC d/DATE from/START_TIME to/END_TIME` <br> e.g., `mark i/ T0123456A d/ 2024-02-20 from/ 11:00 to/ 11:30`                                                                                                                                       |
-| **Unmark**        | `unmark i/NRIC d/DATE from/START_TIME to/END_TIME` <br> e.g., `unmark i/ T0123456A d/ 2024-02-20 from/ 11:00 to/ 11:30`                                                                                                                                   |
-| **List**          | `list`                                                                                                                                                                                                                                                    
+| Action            | Format, Examples                                                                                                                                                                                                                                     |
+|-------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **AddPatient**    | `addPatient i/NRIC n/NAME b/DOB p/PHONE_NUMBER e/EMAIL a/ADDRESS [t/TAG]…​` <br> e.g., `addPatient i/T0123456A n/John Doe b/2001-05-02 p/98765432 e/johnd@example.com a/John street, block 123, #01-01`                                              |
+| **DeletePatient** | `deletePatient NRIC`<br> e.g., `deletePatient T0123456A`                                                                                                                                                                                             |                                                                 |
+| **EditPatient**   | `editPatient NRIC [newn/NEW_NAME] [newp/NEW_PHONE_NUMBER] [newe/NEW_EMAIL] [newa/NEW_ADDRESS] [newt/NEW_TAG]…​`<br> e.g.,`editPatient T0123456A newn/James Lee newe/jameslee@example.com`                                                            |
+| **FindPatient**   | `findPatient n/ KEYWORD [MORE_KEYWORDS]` OR `findPatient i/ KEYWORD`<br> e.g., `findPatient n/ James Jake`                                                                                                                                           |
+| **AddAppt**       | `addAppt i/NRIC d/DATE from/START_TIME to/END_TIME t/APPOINTMENT_TYPE note/NOTE`<br> e.g., `addAppt i/ T0123456A d/ 2024-02-20 from/ 11:00 to/ 11:30 t/ Medical Check-up note/ Routine check-in`                                                     |
+| **DeleteAppt**    | `deleteAppt i/NRIC d/DATE from/START_TIME` <br> e.g., `deleteAppt i/ S8743880A d/ 2024-02-20 from/ 11:00`                                                                                                                          |
+| **EditAppt**      | `editAppt i/NRIC d/DATE from/START_TIME [newd/NEW_DATE] [newfrom/NEW_START_TIME] [newto/NEW_END_TIME] [newt/NEW_APPOINTMENT_TYPE] [newnote/NEW_NOTE]` <br> e.g., `editAppt i/ T0123456A d/ 2024-02-20 from/ 11:00 newd/ 2024-02-21` |
+| **FindAppt**      | `findAppt [i/NRIC] [d/DATE] [from/START_TIME]` <br> e.g., `findAppt i/ T0123456A d/ 2024-02-20 from/ 11:00`                                                                                                                                          |
+| **Mark**          | `mark i/NRIC d/DATE from/START_TIME` <br> e.g., `mark i/ T0123456A d/ 2024-02-20 from/ 11:00`                                                                                                                                   |
+| **Unmark**        | `unmark i/NRIC d/DATE from/START_TIME` <br> e.g., `unmark i/ T0123456A d/ 2024-02-20 from/ 11:00`                                                                                                                              |
+| **List**          | `list`                                                                                                                                                                                                                                               
 | **SwitchView**    | `switchView`
-| **Clear**         | `clear`                                                                                                                                                                                                                                                   |
-| **Exit**          | `exit`                                                                                                                                                                                                                                                    |
-| **Help**          | `help`                                                                                                                                                                                                                                                    |
+| **Clear**         | `clear`                                                                                                                                                                                                                                              |
+| **Exit**          | `exit`                                                                                                                                                                                                                                               |
+| **Help**          | `help`                                                                                                                                                                                                                                               |

--- a/src/main/java/seedu/address/logic/commands/DeleteApptCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteApptCommand.java
@@ -2,7 +2,6 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_END_TIME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_START_TIME;
 
@@ -12,10 +11,7 @@ import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.appointment.Appointment;
-import seedu.address.model.appointment.AppointmentType;
-import seedu.address.model.appointment.Mark;
-import seedu.address.model.appointment.Note;
-import seedu.address.model.appointment.TimePeriod;
+import seedu.address.model.appointment.Time;
 import seedu.address.model.patient.Nric;
 
 /**
@@ -28,38 +24,33 @@ public class DeleteApptCommand extends Command {
     public static final String COMMAND_WORD_ALT = "da";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Deletes the appointment identified by the NRIC, date, start time and end time given.\n"
+            + ": Deletes the appointment identified by the NRIC, date, and start time given.\n"
             + "Parameters: "
             + PREFIX_NRIC + "NRIC "
             + PREFIX_DATE + "DATE "
             + PREFIX_START_TIME + "START_TIME "
-            + PREFIX_END_TIME + "END_TIME "
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NRIC + "T0123456A "
             + PREFIX_DATE + "2024-02-20 "
-            + PREFIX_START_TIME + "11:00 "
-            + PREFIX_END_TIME + "11:30 ";
+            + PREFIX_START_TIME + "11:00 ";
 
     public static final String MESSAGE_DELETE_APPOINTMENT_SUCCESS = "Deleted Appointment: %1$s";
-
-    private Appointment apptToDelete;
     private final Nric targetNric;
     private final Date targetDate;
-    private final TimePeriod targetTimePeriod;
+    private final Time targetStartTime;
 
     /**
      * Creates a DeleteApptCommand to delete the appointment with the
-     * specified {@code Nric, Date, TimePeriod}
+     * specified {@code Nric, Date, StartTime}
      *
      * @param targetNric nric of the Patient matching the existing Appointment to be deleted
      * @param targetDate date of the existing Appointment to be deleted
-     * @param targetTimePeriod timePeriod of the existing Appointment to be deleted
+     * @param targetStartTime startTime of the existing Appointment to be deleted
      */
-    public DeleteApptCommand(Nric targetNric, Date targetDate, TimePeriod targetTimePeriod) {
+    public DeleteApptCommand(Nric targetNric, Date targetDate, Time targetStartTime) {
         this.targetNric = targetNric;
         this.targetDate = targetDate;
-        this.targetTimePeriod = targetTimePeriod;
-        this.apptToDelete = null;
+        this.targetStartTime = targetStartTime;
     }
 
     @Override
@@ -70,13 +61,11 @@ public class DeleteApptCommand extends Command {
             throw new CommandException(Messages.MESSAGE_PATIENT_NRIC_NOT_FOUND);
         }
 
-        Appointment mockAppointmentToMatch = new Appointment(targetNric, targetDate, targetTimePeriod,
-            new AppointmentType("Anything"), new Note("Anything"), new Mark(false));
-        if (!model.hasAppointment(mockAppointmentToMatch)) {
+        if (!model.hasAppointmentWithDetails(targetNric, targetDate, targetStartTime)) {
             throw new CommandException(Messages.MESSAGE_APPOINTMENT_NOT_FOUND);
         }
 
-        this.apptToDelete = model.getMatchingAppointment(targetNric, targetDate, targetTimePeriod);
+        Appointment apptToDelete = model.getMatchingAppointment(targetNric, targetDate, targetStartTime);
         model.cancelAppointment(apptToDelete);
         return new CommandResult(String.format(MESSAGE_DELETE_APPOINTMENT_SUCCESS, Messages.format(apptToDelete)));
     }
@@ -94,19 +83,17 @@ public class DeleteApptCommand extends Command {
 
         DeleteApptCommand otherDeleteApptCommand = (DeleteApptCommand) other;
 
-        // Check if all fields are equal except apptToCancel as not initialised until execute
         return targetNric.equals(otherDeleteApptCommand.targetNric)
                 && targetDate.equals(otherDeleteApptCommand.targetDate)
-                && targetTimePeriod.equals(otherDeleteApptCommand.targetTimePeriod);
+                && targetStartTime.equals(otherDeleteApptCommand.targetStartTime);
     }
 
     @Override
     public String toString() {
-        // Build based on all fields except apptToCancel as not initialised until execute
         return new ToStringBuilder(this)
                 .add("nric", targetNric)
                 .add("date", targetDate)
-                .add("timePeriod", targetTimePeriod)
+                .add("startTime", targetStartTime)
                 .toString();
     }
 }

--- a/src/main/java/seedu/address/logic/commands/EditApptCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditApptCommand.java
@@ -108,7 +108,7 @@ public class EditApptCommand extends Command {
         if (model.hasOverlappingAppointmentExcluding(apptToEdit, editedAppt)) {
             throw new CommandException(MESSAGE_EDIT_OVERLAPPING_APPOINTMENT_FAILURE);
         }
-      
+
         model.setAppointment(apptToEdit, editedAppt);
         model.updateFilteredAppointmentViewList(PREDICATE_SHOW_ALL_APPOINTMENT_VIEWS);
         return new CommandResult(String.format(MESSAGE_EDIT_APPT_SUCCESS, Messages.format(editedAppt)));

--- a/src/main/java/seedu/address/logic/commands/EditApptCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditApptCommand.java
@@ -2,7 +2,6 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_END_TIME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NEW_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NEW_END_TIME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NEW_NOTE;
@@ -23,8 +22,8 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.appointment.Appointment;
 import seedu.address.model.appointment.AppointmentType;
-import seedu.address.model.appointment.Mark;
 import seedu.address.model.appointment.Note;
+import seedu.address.model.appointment.Time;
 import seedu.address.model.appointment.TimePeriod;
 import seedu.address.model.patient.Nric;
 
@@ -38,13 +37,12 @@ public class EditApptCommand extends Command {
     public static final String COMMAND_WORD_ALT = "ea";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Edits the details of the appointment identified by its Nric, Date, End and Start time.\n"
+            + ": Edits the details of the appointment identified by its Nric, Date, and Start time.\n"
             + "Existing values will be overwritten by the input values.\n"
             + "Parameters: "
             + PREFIX_NRIC + "NRIC (must be a valid NRIC in the system) "
             + PREFIX_DATE + "DATE "
             + PREFIX_START_TIME + "START_TIME "
-            + PREFIX_END_TIME + "END_TIME "
             + "[" + PREFIX_NEW_DATE + "NEW_DATE] "
             + "[" + PREFIX_NEW_START_TIME + "NEW_START_TIME] "
             + "[" + PREFIX_NEW_END_TIME + "NEW_END_TIME] "
@@ -54,7 +52,6 @@ public class EditApptCommand extends Command {
             + PREFIX_NRIC + "T0123456A "
             + PREFIX_DATE + "2024-02-20 "
             + PREFIX_START_TIME + "11:00 "
-            + PREFIX_END_TIME + "11:30 "
             + PREFIX_NEW_END_TIME + "12:30 "
             + PREFIX_NEW_TAG + "Blood test "
             + PREFIX_NEW_NOTE + "May come later ";
@@ -64,30 +61,28 @@ public class EditApptCommand extends Command {
 
     private final Nric targetNric;
     private final Date targetDate;
-    private final TimePeriod targetTimePeriod;
-    private Appointment apptToEdit;
+    private final Time targetStartTime;
     private final EditApptDescriptor editApptDescriptor;
 
     /**
      * Creates a EditApptCommand to edit the appointment with the
-     * specified {@code Nric, Date, TimePeriod} using the details
+     * specified {@code Nric, Date, StartTime} using the details
      * from {@code editApptDescriptor}
      * @param nric of the appointment for edit
      * @param date of the appointment to edit
-     * @param timePeriod of the appointment to edit
+     * @param startTime of the appointment to edit
      * @param editApptDescriptor details to edit the appointment with
      */
-    public EditApptCommand(Nric nric, Date date, TimePeriod timePeriod, EditApptDescriptor editApptDescriptor) {
+    public EditApptCommand(Nric nric, Date date, Time startTime, EditApptDescriptor editApptDescriptor) {
         requireNonNull(nric);
         requireNonNull(date);
-        requireNonNull(timePeriod);
+        requireNonNull(startTime);
         requireNonNull(editApptDescriptor);
 
         this.targetNric = nric;
         this.targetDate = date;
-        this.targetTimePeriod = timePeriod;
+        this.targetStartTime = startTime;
         this.editApptDescriptor = new EditApptDescriptor(editApptDescriptor);
-        this.apptToEdit = null;
     }
 
     @Override
@@ -98,15 +93,13 @@ public class EditApptCommand extends Command {
             throw new CommandException(Messages.MESSAGE_PATIENT_NRIC_NOT_FOUND);
         }
 
-        Appointment mockAppointmentToMatch = new Appointment(targetNric, targetDate, targetTimePeriod,
-                new AppointmentType("Anything"), new Note("Anything"), new Mark(false));
-        if (!model.hasAppointment(mockAppointmentToMatch)) {
+        if (!model.hasAppointmentWithDetails(targetNric, targetDate, targetStartTime)) {
             throw new CommandException(Messages.MESSAGE_APPOINTMENT_NOT_FOUND);
         }
 
-        this.apptToEdit = model.getMatchingAppointment(targetNric, targetDate, targetTimePeriod);
-
+        Appointment apptToEdit = model.getMatchingAppointment(targetNric, targetDate, targetStartTime);
         Appointment editedAppt = createEditedAppointment(apptToEdit, editApptDescriptor);
+
         model.setAppointment(apptToEdit, editedAppt);
         model.updateFilteredAppointmentViewList(PREDICATE_SHOW_ALL_APPOINTMENT_VIEWS);
         return new CommandResult(String.format(MESSAGE_EDIT_APPT_SUCCESS, Messages.format(editedAppt)));
@@ -120,10 +113,13 @@ public class EditApptCommand extends Command {
         assert apptToEdit != null;
 
         Date updatedDate = editApptDescriptor.getDate().orElse(apptToEdit.getDate());
-        TimePeriod updatedTimePeriod = editApptDescriptor.getTimePeriod().orElse(apptToEdit.getTimePeriod());
+        Time updatedStartTime = editApptDescriptor.getStartTime().orElse(apptToEdit.getStartTime());
+        Time updatedEndTime = editApptDescriptor.getEndTime().orElse(apptToEdit.getEndTime());
         AppointmentType updatedAppointmentType = editApptDescriptor.getAppointmentType()
                 .orElse(apptToEdit.getAppointmentType());
         Note updatedNote = editApptDescriptor.getNote().orElse(apptToEdit.getNote());
+
+        TimePeriod updatedTimePeriod = new TimePeriod(updatedStartTime, updatedEndTime);
 
         return new Appointment(apptToEdit.getNric(), updatedDate, updatedTimePeriod,
                 updatedAppointmentType, updatedNote, apptToEdit.getMark());
@@ -142,6 +138,8 @@ public class EditApptCommand extends Command {
 
         EditApptCommand otherEditApptCommand = (EditApptCommand) other;
         return targetNric.equals(otherEditApptCommand.targetNric)
+                && targetDate.equals(otherEditApptCommand.targetDate)
+                && targetStartTime.equals(otherEditApptCommand.targetStartTime)
                 && editApptDescriptor.equals(otherEditApptCommand.editApptDescriptor);
     }
 
@@ -150,7 +148,7 @@ public class EditApptCommand extends Command {
         return new ToStringBuilder(this)
                 .add("nric", targetNric)
                 .add("date", targetDate)
-                .add("timePeriod", targetTimePeriod)
+                .add("startTime", targetStartTime)
                 .add("editApptDescriptor", editApptDescriptor)
                 .toString();
     }
@@ -162,7 +160,8 @@ public class EditApptCommand extends Command {
      */
     public static class EditApptDescriptor {
         private Date date;
-        private TimePeriod timePeriod;
+        private Time startTime;
+        private Time endTime;
         private AppointmentType appointmentType;
         private Note note;
 
@@ -173,7 +172,8 @@ public class EditApptCommand extends Command {
          */
         public EditApptDescriptor(EditApptDescriptor toCopy) {
             setDate(toCopy.date);
-            setTimePeriod(toCopy.timePeriod);
+            setStartTime(toCopy.startTime);
+            setEndTime(toCopy.endTime);
             setAppointmentType(toCopy.appointmentType);
             setNote(toCopy.note);
         }
@@ -182,7 +182,7 @@ public class EditApptCommand extends Command {
          * Returns true if at least one field is edited.
          */
         public boolean isAnyFieldEdited() {
-            return CollectionUtil.isAnyNonNull(date, timePeriod, appointmentType, note);
+            return CollectionUtil.isAnyNonNull(date, startTime, endTime, appointmentType, note);
         }
 
         public void setDate(Date date) {
@@ -193,13 +193,22 @@ public class EditApptCommand extends Command {
             return Optional.ofNullable(date);
         }
 
-        public void setTimePeriod(TimePeriod timePeriod) {
-            this.timePeriod = timePeriod;
+        public void setStartTime(Time startTime) {
+            this.startTime = startTime;
         }
 
-        public Optional<TimePeriod> getTimePeriod() {
-            return Optional.ofNullable(timePeriod);
+        public Optional<Time> getStartTime() {
+            return Optional.ofNullable(startTime);
         }
+
+        public void setEndTime(Time endTime) {
+            this.endTime = endTime;
+        }
+
+        public Optional<Time> getEndTime() {
+            return Optional.ofNullable(endTime);
+        }
+
 
         public void setAppointmentType(AppointmentType appointmentType) {
             this.appointmentType = appointmentType;
@@ -230,7 +239,8 @@ public class EditApptCommand extends Command {
 
             EditApptDescriptor otherEditApptDescriptor = (EditApptDescriptor) other;
             return Objects.equals(date, otherEditApptDescriptor.date)
-                    && Objects.equals(timePeriod, otherEditApptDescriptor.timePeriod)
+                    && Objects.equals(startTime, otherEditApptDescriptor.startTime)
+                    && Objects.equals(endTime, otherEditApptDescriptor.endTime)
                     && Objects.equals(appointmentType, otherEditApptDescriptor.appointmentType)
                     && Objects.equals(note, otherEditApptDescriptor.note);
         }
@@ -239,7 +249,8 @@ public class EditApptCommand extends Command {
         public String toString() {
             return new ToStringBuilder(this)
                     .add("date", date)
-                    .add("timePeriod", timePeriod)
+                    .add("startTime", startTime)
+                    .add("endTime", endTime)
                     .add("appointmentType", appointmentType)
                     .add("note", note)
                     .toString();

--- a/src/main/java/seedu/address/logic/commands/MarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkCommand.java
@@ -2,7 +2,6 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_END_TIME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_START_TIME;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_APPOINTMENT_VIEWS;
@@ -13,10 +12,8 @@ import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.appointment.Appointment;
-import seedu.address.model.appointment.AppointmentType;
 import seedu.address.model.appointment.Mark;
-import seedu.address.model.appointment.Note;
-import seedu.address.model.appointment.TimePeriod;
+import seedu.address.model.appointment.Time;
 import seedu.address.model.patient.Nric;
 
 /**
@@ -31,30 +28,29 @@ public class MarkCommand extends Command {
             + "Parameters: "
             + PREFIX_NRIC + "NRIC "
             + PREFIX_DATE + "DATE "
-            + PREFIX_START_TIME + "START_TIME "
-            + PREFIX_END_TIME + "END_TIME";
+            + PREFIX_START_TIME + "START_TIME ";
 
     public static final String MESSAGE_MARK_APPOINTMENT_SUCCESS = "Appointment successfully marked as seen: %1$s";
 
     private final Nric targetNric;
     private final Date targetDate;
-    private final TimePeriod targetTimePeriod;
+    private final Time targetStartTime;
 
     /**
      * Creates a MarkCommand to mark the appointment with the
-     * specified {@code Nric, Date, TimePeriod}
+     * specified {@code Nric, Date, StartTime}
      * @param targetNric nric of the Patient matching the existing Appointment to be marked
      * @param targetDate date of the existing Appointment to be marked
-     * @param targetTimePeriod timePeriod of the existing Appointment to be marked
+     * @param targetStartTime startTime of the existing Appointment to be marked
      */
-    public MarkCommand(Nric targetNric, Date targetDate, TimePeriod targetTimePeriod) {
+    public MarkCommand(Nric targetNric, Date targetDate, Time targetStartTime) {
         requireNonNull(targetNric);
         requireNonNull(targetDate);
-        requireNonNull(targetTimePeriod);
+        requireNonNull(targetStartTime);
 
         this.targetNric = targetNric;
         this.targetDate = targetDate;
-        this.targetTimePeriod = targetTimePeriod;
+        this.targetStartTime = targetStartTime;
     }
 
     @Override
@@ -65,13 +61,11 @@ public class MarkCommand extends Command {
             throw new CommandException(Messages.MESSAGE_PATIENT_NRIC_NOT_FOUND);
         }
 
-        Appointment mockAppointmentToMatch = new Appointment(targetNric, targetDate, targetTimePeriod,
-            new AppointmentType("Anything"), new Note("Anything"), new Mark(false));
-        if (!model.hasAppointment(mockAppointmentToMatch)) {
+        if (!model.hasAppointmentWithDetails(targetNric, targetDate, targetStartTime)) {
             throw new CommandException(Messages.MESSAGE_APPOINTMENT_NOT_FOUND);
         }
 
-        Appointment apptToMark = model.getMatchingAppointment(targetNric, targetDate, targetTimePeriod);
+        Appointment apptToMark = model.getMatchingAppointment(targetNric, targetDate, targetStartTime);
 
         Appointment markedAppt = createMarkedAppointment(apptToMark);
         model.setAppointment(apptToMark, markedAppt);
@@ -102,7 +96,7 @@ public class MarkCommand extends Command {
         MarkCommand otherMarkCommand = (MarkCommand) other;
         return targetNric.equals(otherMarkCommand.targetNric)
                 && targetDate.equals(otherMarkCommand.targetDate)
-                && targetTimePeriod.equals(otherMarkCommand.targetTimePeriod);
+                && targetStartTime.equals(otherMarkCommand.targetStartTime);
     }
 
     @Override
@@ -110,7 +104,7 @@ public class MarkCommand extends Command {
         return new ToStringBuilder(this)
                 .add("nric", targetNric)
                 .add("date", targetDate)
-                .add("timePeriod", targetTimePeriod)
+                .add("startTime", targetStartTime)
                 .toString();
     }
 }

--- a/src/main/java/seedu/address/logic/commands/UnmarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnmarkCommand.java
@@ -2,7 +2,6 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_END_TIME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_START_TIME;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_APPOINTMENT_VIEWS;
@@ -13,10 +12,8 @@ import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.appointment.Appointment;
-import seedu.address.model.appointment.AppointmentType;
 import seedu.address.model.appointment.Mark;
-import seedu.address.model.appointment.Note;
-import seedu.address.model.appointment.TimePeriod;
+import seedu.address.model.appointment.Time;
 import seedu.address.model.patient.Nric;
 
 /**
@@ -31,31 +28,30 @@ public class UnmarkCommand extends Command {
             + "Parameters: "
             + PREFIX_NRIC + "NRIC "
             + PREFIX_DATE + "DATE "
-            + PREFIX_START_TIME + "START_TIME "
-            + PREFIX_END_TIME + "END_TIME";
+            + PREFIX_START_TIME + "START_TIME ";
 
     public static final String MESSAGE_UNMARK_APPOINTMENT_SUCCESS =
             "Appointment successfully unmarked as not seen: %1$s";
 
     private final Nric targetNric;
     private final Date targetDate;
-    private final TimePeriod targetTimePeriod;
+    private final Time targetStartTime;
 
     /**
      * Creates a UnmarkCommand to unmark the appointment with the
-     * specified {@code Nric, Date, TimePeriod}
+     * specified {@code Nric, Date, StartTime}
      * @param targetNric nric of the Patient matching the existing Appointment to be unmarked
      * @param targetDate date of the existing Appointment to be unmarked
-     * @param targetTimePeriod timePeriod of the existing Appointment to be unmarked
+     * @param targetStartTime startTime of the existing Appointment to be unmarked
      */
-    public UnmarkCommand(Nric targetNric, Date targetDate, TimePeriod targetTimePeriod) {
+    public UnmarkCommand(Nric targetNric, Date targetDate, Time targetStartTime) {
         requireNonNull(targetNric);
         requireNonNull(targetDate);
-        requireNonNull(targetTimePeriod);
+        requireNonNull(targetStartTime);
 
         this.targetNric = targetNric;
         this.targetDate = targetDate;
-        this.targetTimePeriod = targetTimePeriod;
+        this.targetStartTime = targetStartTime;
     }
 
     @Override
@@ -66,13 +62,11 @@ public class UnmarkCommand extends Command {
             throw new CommandException(Messages.MESSAGE_PATIENT_NRIC_NOT_FOUND);
         }
 
-        Appointment mockAppointmentToMatch = new Appointment(targetNric, targetDate, targetTimePeriod,
-            new AppointmentType("Anything"), new Note("Anything"), new Mark(false));
-        if (!model.hasAppointment(mockAppointmentToMatch)) {
+        if (!model.hasAppointmentWithDetails(targetNric, targetDate, targetStartTime)) {
             throw new CommandException(Messages.MESSAGE_APPOINTMENT_NOT_FOUND);
         }
 
-        Appointment apptToUnmark = model.getMatchingAppointment(targetNric, targetDate, targetTimePeriod);
+        Appointment apptToUnmark = model.getMatchingAppointment(targetNric, targetDate, targetStartTime);
 
         Appointment unmarkedAppt = createUnmarkedAppointment(apptToUnmark);
         model.setAppointment(apptToUnmark, unmarkedAppt);
@@ -104,7 +98,7 @@ public class UnmarkCommand extends Command {
         UnmarkCommand otherUnmarkCommand = (UnmarkCommand) other;
         return targetNric.equals(otherUnmarkCommand.targetNric)
                 && targetDate.equals(otherUnmarkCommand.targetDate)
-                && targetTimePeriod.equals(otherUnmarkCommand.targetTimePeriod);
+                && targetStartTime.equals(otherUnmarkCommand.targetStartTime);
     }
 
     @Override
@@ -112,7 +106,7 @@ public class UnmarkCommand extends Command {
         return new ToStringBuilder(this)
                 .add("nric", targetNric)
                 .add("date", targetDate)
-                .add("timePeriod", targetTimePeriod)
+                .add("startTime", targetStartTime)
                 .toString();
     }
 }

--- a/src/main/java/seedu/address/logic/parser/DeleteApptCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteApptCommandParser.java
@@ -2,7 +2,6 @@ package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_END_TIME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_START_TIME;
 
@@ -11,7 +10,7 @@ import java.util.stream.Stream;
 import seedu.address.commons.core.date.Date;
 import seedu.address.logic.commands.DeleteApptCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.appointment.TimePeriod;
+import seedu.address.model.appointment.Time;
 import seedu.address.model.patient.Nric;
 
 /**
@@ -26,24 +25,19 @@ public class DeleteApptCommandParser implements Parser<DeleteApptCommand> {
      */
     public DeleteApptCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NRIC, PREFIX_DATE, PREFIX_START_TIME,
-                        PREFIX_END_TIME);
+                ArgumentTokenizer.tokenize(args, PREFIX_NRIC, PREFIX_DATE, PREFIX_START_TIME);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_NRIC, PREFIX_DATE, PREFIX_START_TIME,
-                PREFIX_END_TIME)
+        if (!arePrefixesPresent(argMultimap, PREFIX_NRIC, PREFIX_DATE, PREFIX_START_TIME)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteApptCommand.MESSAGE_USAGE));
         }
 
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NRIC, PREFIX_DATE, PREFIX_START_TIME,
-                PREFIX_END_TIME);
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NRIC, PREFIX_DATE, PREFIX_START_TIME);
         Nric nric = ParserUtil.parseNric(argMultimap.getValue(PREFIX_NRIC).get());
         Date date = ParserUtil.parseDate(argMultimap.getValue(PREFIX_DATE).get());
-        TimePeriod timePeriod = ParserUtil.parseTimePeriod(
-                argMultimap.getValue(PREFIX_START_TIME).get(),
-                argMultimap.getValue(PREFIX_END_TIME).get());
+        Time startTime = ParserUtil.parseTime(argMultimap.getValue(PREFIX_START_TIME).get());
 
-        return new DeleteApptCommand(nric, date, timePeriod);
+        return new DeleteApptCommand(nric, date, startTime);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/EditApptCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditApptCommandParser.java
@@ -3,7 +3,6 @@ package seedu.address.logic.parser;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_END_TIME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NEW_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NEW_END_TIME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NEW_NOTE;
@@ -17,7 +16,7 @@ import java.util.stream.Stream;
 import seedu.address.commons.core.date.Date;
 import seedu.address.logic.commands.EditApptCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.appointment.TimePeriod;
+import seedu.address.model.appointment.Time;
 import seedu.address.model.patient.Nric;
 
 /**
@@ -33,24 +32,22 @@ public class EditApptCommandParser implements Parser<EditApptCommand> {
     public EditApptCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args,
-                PREFIX_NRIC, PREFIX_DATE, PREFIX_START_TIME, PREFIX_END_TIME,
+                PREFIX_NRIC, PREFIX_DATE, PREFIX_START_TIME,
                 PREFIX_NEW_DATE, PREFIX_NEW_START_TIME, PREFIX_NEW_END_TIME,
                 PREFIX_NEW_TAG, PREFIX_NEW_NOTE);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_NRIC, PREFIX_DATE, PREFIX_START_TIME, PREFIX_END_TIME)
+        if (!arePrefixesPresent(argMultimap, PREFIX_NRIC, PREFIX_DATE, PREFIX_START_TIME)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditApptCommand.MESSAGE_USAGE));
         }
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NRIC, PREFIX_DATE, PREFIX_START_TIME,
-                PREFIX_END_TIME, PREFIX_NEW_DATE, PREFIX_NEW_START_TIME, PREFIX_NEW_END_TIME,
+                PREFIX_NEW_DATE, PREFIX_NEW_START_TIME, PREFIX_NEW_END_TIME,
                 PREFIX_NEW_TAG, PREFIX_NEW_NOTE);
 
         Nric targetNric = ParserUtil.parseNric(argMultimap.getValue(PREFIX_NRIC).get());
         Date targetDate = ParserUtil.parseDate(argMultimap.getValue(PREFIX_DATE).get());
-        TimePeriod targetTimePeriod = ParserUtil.parseTimePeriod(
-                argMultimap.getValue(PREFIX_START_TIME).get(),
-                argMultimap.getValue(PREFIX_END_TIME).get());
+        Time targetStartTime = ParserUtil.parseTime(argMultimap.getValue(PREFIX_START_TIME).get());
 
 
 
@@ -59,26 +56,11 @@ public class EditApptCommandParser implements Parser<EditApptCommand> {
         if (argMultimap.getValue(PREFIX_NEW_DATE).isPresent()) {
             editApptDescriptor.setDate(ParserUtil.parseDate(argMultimap.getValue(PREFIX_NEW_DATE).get()));
         }
-        if (argMultimap.getValue(PREFIX_NEW_START_TIME).isPresent()
-                && argMultimap.getValue(PREFIX_NEW_END_TIME).isPresent()) {
-            //with both new times
-            editApptDescriptor.setTimePeriod(ParserUtil.parseTimePeriod(
-                    argMultimap.getValue(PREFIX_NEW_START_TIME).get(),
-                    argMultimap.getValue(PREFIX_NEW_END_TIME).get()));
+        if (argMultimap.getValue(PREFIX_NEW_START_TIME).isPresent()) {
+            editApptDescriptor.setStartTime(ParserUtil.parseTime(argMultimap.getValue(PREFIX_NEW_START_TIME).get()));
         }
-        if (argMultimap.getValue(PREFIX_NEW_START_TIME).isPresent()
-                && argMultimap.getValue(PREFIX_NEW_END_TIME).isEmpty()) {
-            //with old end time
-            editApptDescriptor.setTimePeriod(ParserUtil.parseTimePeriod(
-                    argMultimap.getValue(PREFIX_NEW_START_TIME).get(),
-                    argMultimap.getValue(PREFIX_END_TIME).get()));
-        }
-        if (argMultimap.getValue(PREFIX_NEW_START_TIME).isEmpty()
-                && argMultimap.getValue(PREFIX_NEW_END_TIME).isPresent()) {
-            //with old start time
-            editApptDescriptor.setTimePeriod(ParserUtil.parseTimePeriod(
-                    argMultimap.getValue(PREFIX_START_TIME).get(),
-                    argMultimap.getValue(PREFIX_NEW_END_TIME).get()));
+        if (argMultimap.getValue(PREFIX_NEW_END_TIME).isPresent()) {
+            editApptDescriptor.setEndTime(ParserUtil.parseTime(argMultimap.getValue(PREFIX_NEW_END_TIME).get()));
         }
         if (argMultimap.getValue(PREFIX_NEW_TAG).isPresent()) {
             editApptDescriptor.setAppointmentType(ParserUtil
@@ -93,7 +75,7 @@ public class EditApptCommandParser implements Parser<EditApptCommand> {
             throw new ParseException(EditApptCommand.MESSAGE_EDIT_APPT_NO_FIELDS_FAILURE);
         }
 
-        return new EditApptCommand(targetNric, targetDate, targetTimePeriod, editApptDescriptor);
+        return new EditApptCommand(targetNric, targetDate, targetStartTime, editApptDescriptor);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/MarkCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/MarkCommandParser.java
@@ -2,7 +2,6 @@ package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_END_TIME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_START_TIME;
 
@@ -11,7 +10,7 @@ import java.util.stream.Stream;
 import seedu.address.commons.core.date.Date;
 import seedu.address.logic.commands.MarkCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.appointment.TimePeriod;
+import seedu.address.model.appointment.Time;
 import seedu.address.model.patient.Nric;
 
 
@@ -27,24 +26,19 @@ public class MarkCommandParser implements Parser<MarkCommand> {
      */
     public MarkCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NRIC, PREFIX_DATE, PREFIX_START_TIME,
-                        PREFIX_END_TIME);
+                ArgumentTokenizer.tokenize(args, PREFIX_NRIC, PREFIX_DATE, PREFIX_START_TIME);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_NRIC, PREFIX_DATE, PREFIX_START_TIME,
-                PREFIX_END_TIME)
+        if (!arePrefixesPresent(argMultimap, PREFIX_NRIC, PREFIX_DATE, PREFIX_START_TIME)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MarkCommand.MESSAGE_USAGE));
         }
 
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NRIC, PREFIX_DATE, PREFIX_START_TIME,
-                PREFIX_END_TIME);
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NRIC, PREFIX_DATE, PREFIX_START_TIME);
         Nric nric = ParserUtil.parseNric(argMultimap.getValue(PREFIX_NRIC).get());
         Date date = ParserUtil.parseDate(argMultimap.getValue(PREFIX_DATE).get());
-        TimePeriod timePeriod = ParserUtil.parseTimePeriod(
-                argMultimap.getValue(PREFIX_START_TIME).get(),
-                argMultimap.getValue(PREFIX_END_TIME).get());
+        Time startTime = ParserUtil.parseTime(argMultimap.getValue(PREFIX_START_TIME).get());
 
-        return new MarkCommand(nric, date, timePeriod);
+        return new MarkCommand(nric, date, startTime);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/UnmarkCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UnmarkCommandParser.java
@@ -2,7 +2,6 @@ package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_END_TIME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_START_TIME;
 
@@ -11,7 +10,7 @@ import java.util.stream.Stream;
 import seedu.address.commons.core.date.Date;
 import seedu.address.logic.commands.UnmarkCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.appointment.TimePeriod;
+import seedu.address.model.appointment.Time;
 import seedu.address.model.patient.Nric;
 
 
@@ -27,24 +26,19 @@ public class UnmarkCommandParser implements Parser<UnmarkCommand> {
      */
     public UnmarkCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NRIC, PREFIX_DATE, PREFIX_START_TIME,
-                        PREFIX_END_TIME);
+                ArgumentTokenizer.tokenize(args, PREFIX_NRIC, PREFIX_DATE, PREFIX_START_TIME);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_NRIC, PREFIX_DATE, PREFIX_START_TIME,
-                PREFIX_END_TIME)
+        if (!arePrefixesPresent(argMultimap, PREFIX_NRIC, PREFIX_DATE, PREFIX_START_TIME)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnmarkCommand.MESSAGE_USAGE));
         }
 
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NRIC, PREFIX_DATE, PREFIX_START_TIME,
-                PREFIX_END_TIME);
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NRIC, PREFIX_DATE, PREFIX_START_TIME);
         Nric nric = ParserUtil.parseNric(argMultimap.getValue(PREFIX_NRIC).get());
         Date date = ParserUtil.parseDate(argMultimap.getValue(PREFIX_DATE).get());
-        TimePeriod timePeriod = ParserUtil.parseTimePeriod(
-                argMultimap.getValue(PREFIX_START_TIME).get(),
-                argMultimap.getValue(PREFIX_END_TIME).get());
+        Time startTime = ParserUtil.parseTime(argMultimap.getValue(PREFIX_START_TIME).get());
 
-        return new UnmarkCommand(nric, date, timePeriod);
+        return new UnmarkCommand(nric, date, startTime);
     }
 
     /**

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -11,7 +11,7 @@ import seedu.address.model.appointment.Appointment;
 import seedu.address.model.appointment.AppointmentList;
 import seedu.address.model.appointment.AppointmentView;
 import seedu.address.model.appointment.AppointmentViewList;
-import seedu.address.model.appointment.TimePeriod;
+import seedu.address.model.appointment.Time;
 import seedu.address.model.patient.Nric;
 import seedu.address.model.patient.Patient;
 import seedu.address.model.patient.UniquePatientList;
@@ -213,14 +213,18 @@ public class AddressBook implements ReadOnlyAddressBook {
         return appointmentView.asUnmodifiableObservableList();
     }
 
-    public Appointment getMatchingAppointment(Nric nric, Date date, TimePeriod timePeriod) {
-        return appointments.getMatchingAppointment(nric, date, timePeriod);
+    public Appointment getMatchingAppointment(Nric nric, Date date, Time startTime) {
+        return appointments.getMatchingAppointment(nric, date, startTime);
     }
 
-    /** delete appointments when patient is deleted */
+    /** Delete appointments that have a target Nric, meant to help with cascading */
     public void deleteAppointmentsWithNric(Nric targetNric) {
         appointments.deleteAppointmentsWithNric(targetNric);
         this.appointmentView.setAppointmentViews(patients, appointments);
+    }
+
+    public boolean hasAppointmentWithDetails(Nric nric, Date date, Time startTime) {
+        return appointments.hasAppointmentWithDetails(nric, date, startTime);
     }
 
     /**
@@ -251,4 +255,5 @@ public class AddressBook implements ReadOnlyAddressBook {
     public int hashCode() {
         return patients.hashCode();
     }
+
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -8,7 +8,7 @@ import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.date.Date;
 import seedu.address.model.appointment.Appointment;
 import seedu.address.model.appointment.AppointmentView;
-import seedu.address.model.appointment.TimePeriod;
+import seedu.address.model.appointment.Time;
 import seedu.address.model.patient.Nric;
 import seedu.address.model.patient.Patient;
 
@@ -150,9 +150,12 @@ public interface Model {
      */
     void updateFilteredAppointmentDayViewList();
 
-    /** Returns an Appointment that matches based on Nric, Date and TimePeriod given **/
-    Appointment getMatchingAppointment(Nric nric, Date date, TimePeriod timePeriod);
+    /** Returns an Appointment that matches based on Nric, Date and StartTime given **/
+    Appointment getMatchingAppointment(Nric nric, Date date, Time timePeriod);
 
     /** Deletes all appointments of a targetNric **/
     void deleteAppointmentsWithNric(Nric targetNric);
+
+    /** Returns true if there is an existing appointment with the details Nric, Date and StartTime given **/
+    boolean hasAppointmentWithDetails(Nric targetNric, Date targetDate, Time targetStartTime);
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -17,7 +17,7 @@ import seedu.address.commons.core.date.Date;
 import seedu.address.model.appointment.Appointment;
 import seedu.address.model.appointment.AppointmentContainsKeywordsPredicate;
 import seedu.address.model.appointment.AppointmentView;
-import seedu.address.model.appointment.TimePeriod;
+import seedu.address.model.appointment.Time;
 import seedu.address.model.patient.Nric;
 import seedu.address.model.patient.Patient;
 
@@ -166,14 +166,19 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public Appointment getMatchingAppointment(Nric nric, Date date, TimePeriod timePeriod) {
-        return addressBook.getMatchingAppointment(nric, date, timePeriod);
+    public Appointment getMatchingAppointment(Nric nric, Date date, Time startTime) {
+        return addressBook.getMatchingAppointment(nric, date, startTime);
     }
 
     @Override
     public void deleteAppointmentsWithNric(Nric targetNric) {
         requireNonNull(targetNric);
         addressBook.deleteAppointmentsWithNric(targetNric);
+    }
+
+    @Override
+    public boolean hasAppointmentWithDetails(Nric nric, Date date, Time startTime) {
+        return addressBook.hasAppointmentWithDetails(nric, date, startTime);
     }
 
     //=========== Filtered Patient List Accessors =============================================================

--- a/src/main/java/seedu/address/model/appointment/AppointmentList.java
+++ b/src/main/java/seedu/address/model/appointment/AppointmentList.java
@@ -203,10 +203,8 @@ public class AppointmentList implements Iterable<Appointment> {
                 return true;
             }
         }
-
         return false;
     }
-  
     /** Return true if new appt to be added overlaps with existing appointment of same Nric **/
     public boolean samePatientHasOverlappingAppointment(Appointment targetAppt) {
         requireNonNull(targetAppt);

--- a/src/main/java/seedu/address/model/appointment/AppointmentList.java
+++ b/src/main/java/seedu/address/model/appointment/AppointmentList.java
@@ -115,18 +115,18 @@ public class AppointmentList implements Iterable<Appointment> {
     }
 
     /**
-     * Returns an Appointment that matches from the Appointment list based on {@code Nric, Date, TimePeriod} given.
+     * Returns an Appointment that matches from the Appointment list based on {@code Nric, Date, StartTime} given.
      * Throws an {@code AppointmentNotFoundException} if no matching appointment is found.
      */
-    public Appointment getMatchingAppointment(Nric nricToMatch, Date dateToMatch, TimePeriod timePeriodToMatch) {
+    public Appointment getMatchingAppointment(Nric nricToMatch, Date dateToMatch, Time startTimeToMatch) {
         requireNonNull(nricToMatch);
         requireNonNull(dateToMatch);
-        requireNonNull(timePeriodToMatch);
+        requireNonNull(startTimeToMatch);
 
         for (Appointment appointment : this) {
             if (appointment.getNric().equals(nricToMatch)
                     && appointment.getDate().equals(dateToMatch)
-                    && appointment.getTimePeriod().equals(timePeriodToMatch)) {
+                    && appointment.getStartTime().equals(startTimeToMatch)) {
                 return appointment;
             }
         }
@@ -178,5 +178,24 @@ public class AppointmentList implements Iterable<Appointment> {
     public void deleteAppointmentsWithNric(Nric nric) {
         requireNonNull(nric);
         internalList.removeIf(appointment -> appointment.getNric().equals(nric));
+    }
+
+    /**
+     * Returns true if appointment list has appointment with {@code nric, date, startTime}
+     */
+    public boolean hasAppointmentWithDetails(Nric nricToMatch, Date dateToMatch, Time startTimeToMatch) {
+        requireNonNull(nricToMatch);
+        requireNonNull(dateToMatch);
+        requireNonNull(startTimeToMatch);
+
+        for (Appointment appointment : this) {
+            if (appointment.getNric().equals(nricToMatch)
+                    && appointment.getDate().equals(dateToMatch)
+                    && appointment.getStartTime().equals(startTimeToMatch)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/test/java/seedu/address/logic/commands/AddApptCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddApptCommandTest.java
@@ -26,7 +26,7 @@ import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.ReadOnlyUserPrefs;
 import seedu.address.model.appointment.Appointment;
 import seedu.address.model.appointment.AppointmentView;
-import seedu.address.model.appointment.TimePeriod;
+import seedu.address.model.appointment.Time;
 import seedu.address.model.patient.Nric;
 import seedu.address.model.patient.Patient;
 import seedu.address.testutil.AppointmentBuilder;
@@ -231,12 +231,17 @@ public class AddApptCommandTest {
         }
 
         @Override
-        public Appointment getMatchingAppointment(Nric nric, Date date, TimePeriod timePeriod) {
+        public Appointment getMatchingAppointment(Nric nric, Date date, Time startTime) {
             throw new AssertionError("This method should not be called.");
         }
 
         @Override
         public void deleteAppointmentsWithNric(Nric targetNric) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean hasAppointmentWithDetails(Nric targetNric, Date targetDate, Time targetStartTime) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/logic/commands/AddPatientCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddPatientCommandTest.java
@@ -229,7 +229,7 @@ public class AddPatientCommandTest {
         public boolean hasAppointmentWithDetails(Nric targetNric, Date targetDate, Time targetStartTime) {
             throw new AssertionError("This method should not be called.");
         }
-      
+
         @Override
         public boolean samePatientHasOverlappingAppointment(Appointment apptToAdd) {
             throw new AssertionError("This method should not be called.");

--- a/src/test/java/seedu/address/logic/commands/AddPatientCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddPatientCommandTest.java
@@ -25,7 +25,7 @@ import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.ReadOnlyUserPrefs;
 import seedu.address.model.appointment.Appointment;
 import seedu.address.model.appointment.AppointmentView;
-import seedu.address.model.appointment.TimePeriod;
+import seedu.address.model.appointment.Time;
 import seedu.address.model.patient.Nric;
 import seedu.address.model.patient.Patient;
 import seedu.address.testutil.PatientBuilder;
@@ -216,12 +216,17 @@ public class AddPatientCommandTest {
         }
 
         @Override
-        public Appointment getMatchingAppointment(Nric nric, Date date, TimePeriod timePeriod) {
+        public Appointment getMatchingAppointment(Nric nric, Date date, Time startTime) {
             throw new AssertionError("This method should not be called.");
         }
 
         @Override
         public void deleteAppointmentsWithNric(Nric targetNric) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean hasAppointmentWithDetails(Nric targetNric, Date targetDate, Time targetStartTime) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -153,8 +153,14 @@ public class CommandTestUtil {
     public static final String INVALID_APPOINTMENT_NOTE_DESC = " " + PREFIX_NOTE + "@@"; // non-alphanumeric
     public static final String INVALID_APPOINTMENT_MARK_DESC = " " + PREFIX_NOTE + "abc"; // not true or false
     public static final String INVALID_NEW_DATE_DESC = " " + PREFIX_NEW_DATE + "2024-32-32"; //exceeds month & day range
-    public static final String INVALID_NEW_START_TIME_DESC = " " + PREFIX_NEW_START_TIME + "11:30"; // is after end time
-    public static final String INVALID_NEW_END_TIME_DESC = " " + PREFIX_NEW_END_TIME + "11:00"; // is before start time
+    public static final String INVALID_NEW_START_TIME_RANGE_DESC = " " + PREFIX_NEW_START_TIME
+            + "11:30"; // is after end time
+    public static final String INVALID_NEW_END_TIME_RANGE_DESC = " " + PREFIX_NEW_END_TIME
+            + "11:00"; // is before start time
+    public static final String INVALID_NEW_START_TIME_DESC = " " + PREFIX_NEW_START_TIME
+            + "24:00"; // exceeds 24 hour clock range
+    public static final String INVALID_NEW_END_TIME_DESC = " " + PREFIX_NEW_END_TIME
+            + "24:00"; // exceeds 24 hour clock range
     public static final String INVALID_NEW_APPOINTMENT_TYPE_DESC = " " + PREFIX_NEW_TAG + "  "; // only white spaces
     public static final String INVALID_NEW_APPOINTMENT_NOTE_DESC = " " + PREFIX_NEW_NOTE + "@@"; // non-alphanumeric
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
@@ -181,12 +187,14 @@ public class CommandTestUtil {
     static {
         DESC_APPT_AMY = new EditApptDescriptorBuilder()
                 .withDate(VALID_APPOINTMENT_DATE_AMY)
-                .withTimePeriod(VALID_APPOINTMENT_START_TIME_AMY, VALID_APPOINTMENT_END_TIME_AMY)
+                .withStartTime(VALID_APPOINTMENT_START_TIME_AMY)
+                .withEndTime(VALID_APPOINTMENT_END_TIME_AMY)
                 .withAppointmentType(VALID_APPOINTMENT_TYPE_AMY)
                 .withNote(VALID_APPOINTMENT_NOTE_AMY).build();
         DESC_APPT_BOB = new EditApptDescriptorBuilder()
                 .withDate(VALID_APPOINTMENT_DATE_BOB)
-                .withTimePeriod(VALID_APPOINTMENT_START_TIME_BOB, VALID_APPOINTMENT_END_TIME_BOB)
+                .withStartTime(VALID_APPOINTMENT_START_TIME_BOB)
+                .withEndTime(VALID_APPOINTMENT_END_TIME_BOB)
                 .withAppointmentType(VALID_APPOINTMENT_TYPE_BOB)
                 .withNote(VALID_APPOINTMENT_NOTE_BOB).build();
     }

--- a/src/test/java/seedu/address/logic/commands/DeleteApptCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteApptCommandTest.java
@@ -32,7 +32,7 @@ public class DeleteApptCommandTest {
         DeleteApptCommand deleteApptCommand = new DeleteApptCommand(
                 ALICE_APPT.getNric(),
                 ALICE_APPT.getDate(),
-                ALICE_APPT.getTimePeriod()
+                ALICE_APPT.getStartTime()
         );
 
         // Expected message after successful cancellation
@@ -47,7 +47,7 @@ public class DeleteApptCommandTest {
         DeleteApptCommand deleteApptCommand = new DeleteApptCommand(
                 ALICE_APPT.getNric(),
                 new Date("1900-02-02"),
-                ALICE_APPT.getTimePeriod()
+                ALICE_APPT.getStartTime()
         );
 
         assertCommandFailure(deleteApptCommand, model, Messages.MESSAGE_APPOINTMENT_NOT_FOUND);
@@ -59,7 +59,7 @@ public class DeleteApptCommandTest {
         DeleteApptCommand deleteApptCommand = new DeleteApptCommand(
                 missingNric,
                 ALICE_APPT.getDate(),
-                ALICE_APPT.getTimePeriod()
+                ALICE_APPT.getStartTime()
         );
 
         assertCommandFailure(deleteApptCommand, model, Messages.MESSAGE_PATIENT_NRIC_NOT_FOUND);
@@ -71,12 +71,12 @@ public class DeleteApptCommandTest {
         DeleteApptCommand cancelFirstAppointment = new DeleteApptCommand(
                 ALICE_APPT.getNric(),
                 ALICE_APPT.getDate(),
-                ALICE_APPT.getTimePeriod()
+                ALICE_APPT.getStartTime()
         );
         DeleteApptCommand cancelSecondAppointment = new DeleteApptCommand(
                 ALICE_APPT_1.getNric(),
                 ALICE_APPT_1.getDate(),
-                ALICE_APPT_1.getTimePeriod()
+                ALICE_APPT_1.getStartTime()
         );
 
         // same object -> returns true
@@ -86,7 +86,7 @@ public class DeleteApptCommandTest {
         DeleteApptCommand cancelFirstAppointmentCopy = new DeleteApptCommand(
                 ALICE_APPT.getNric(),
                 ALICE_APPT.getDate(),
-                ALICE_APPT.getTimePeriod()
+                ALICE_APPT.getStartTime()
         );
         assertTrue(cancelFirstAppointment.equals(cancelFirstAppointmentCopy));
 
@@ -106,13 +106,13 @@ public class DeleteApptCommandTest {
         DeleteApptCommand deleteApptCommand = new DeleteApptCommand(
                 ALICE_APPT.getNric(),
                 ALICE_APPT.getDate(),
-                ALICE_APPT.getTimePeriod()
+                ALICE_APPT.getStartTime()
         );
 
         String expected = DeleteApptCommand.class.getCanonicalName()
                 + "{nric=" + ALICE_APPT.getNric() + ", "
                 + "date=" + ALICE_APPT.getDate() + ", "
-                + "timePeriod=" + ALICE_APPT.getTimePeriod() + "}";
+                + "startTime=" + ALICE_APPT.getStartTime() + "}";
         assertEquals(expected, deleteApptCommand.toString());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/EditApptCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditApptCommandTest.java
@@ -125,7 +125,7 @@ public class EditApptCommandTest {
         EditApptCommand editApptCommand = new EditApptCommand(
                 ALICE_APPT.getNric(),
                 ALICE_APPT.getDate(),
-                ALICE_APPT.getTimePeriod(),
+                ALICE_APPT.getStartTime(),
                 descriptor
         );
 

--- a/src/test/java/seedu/address/logic/commands/EditApptCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditApptCommandTest.java
@@ -26,7 +26,6 @@ import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.appointment.Appointment;
 import seedu.address.model.appointment.Time;
-import seedu.address.model.appointment.TimePeriod;
 import seedu.address.model.patient.Nric;
 import seedu.address.testutil.AppointmentBuilder;
 import seedu.address.testutil.EditApptDescriptorBuilder;
@@ -44,7 +43,7 @@ public class EditApptCommandTest {
         Appointment editedAppt = new AppointmentBuilder().withNric(ALICE_APPT.getNric().value).build();
         EditApptCommand.EditApptDescriptor descriptor = new EditApptDescriptorBuilder(editedAppt).build();
         EditApptCommand editApptCommand = new EditApptCommand(ALICE_APPT.getNric(), ALICE_APPT.getDate(),
-                ALICE_APPT.getTimePeriod(), descriptor);
+                ALICE_APPT.getStartTime(), descriptor);
 
         String expectedMessage = String.format(EditApptCommand.MESSAGE_EDIT_APPT_SUCCESS,
                 Messages.format(editedAppt));
@@ -62,9 +61,9 @@ public class EditApptCommandTest {
                 .withStartTime(VALID_APPOINTMENT_START_TIME_AMY).withEndTime(VALID_APPOINTMENT_END_TIME_AMY).build();
 
         EditApptDescriptor descriptor = new EditApptDescriptorBuilder().withDate(VALID_APPOINTMENT_DATE_AMY)
-                .withTimePeriod(VALID_APPOINTMENT_START_TIME_AMY, VALID_APPOINTMENT_END_TIME_AMY).build();
+                .withStartTime(VALID_APPOINTMENT_START_TIME_AMY).withEndTime(VALID_APPOINTMENT_END_TIME_AMY).build();
         EditApptCommand editApptCommand = new EditApptCommand(ALICE_APPT.getNric(),
-                ALICE_APPT.getDate(), ALICE_APPT.getTimePeriod(), descriptor);
+                ALICE_APPT.getDate(), ALICE_APPT.getStartTime(), descriptor);
 
         String expectedMessage = String.format(EditApptCommand.MESSAGE_EDIT_APPT_SUCCESS,
                 Messages.format(editedAppt));
@@ -79,9 +78,9 @@ public class EditApptCommandTest {
     public void execute_noFieldSpecified_success() {
         EditApptCommand editApptCommand =
                 new EditApptCommand(ALICE_APPT.getNric(),
-                        ALICE_APPT.getDate(), ALICE_APPT.getTimePeriod(), new EditApptCommand.EditApptDescriptor());
+                        ALICE_APPT.getDate(), ALICE_APPT.getStartTime(), new EditApptCommand.EditApptDescriptor());
         Appointment editedAppointment = model.getMatchingAppointment(ALICE_APPT.getNric(),
-                ALICE_APPT.getDate(), ALICE_APPT.getTimePeriod());
+                ALICE_APPT.getDate(), ALICE_APPT.getStartTime());
 
         String expectedMessage = String.format(EditApptCommand.MESSAGE_EDIT_APPT_SUCCESS,
                 Messages.format(editedAppointment));
@@ -97,7 +96,7 @@ public class EditApptCommandTest {
         Nric notFoundNric = new Nric("G9999999X");
         EditApptDescriptor descriptor = new EditApptDescriptorBuilder().withDate(VALID_APPOINTMENT_DATE_AMY).build();
         EditApptCommand editApptCommand = new EditApptCommand(notFoundNric,
-                ALICE_APPT.getDate(), ALICE_APPT.getTimePeriod(), descriptor);
+                ALICE_APPT.getDate(), ALICE_APPT.getStartTime(), descriptor);
 
         assertCommandFailure(editApptCommand, model, Messages.MESSAGE_PATIENT_NRIC_NOT_FOUND);
     }
@@ -108,7 +107,7 @@ public class EditApptCommandTest {
         EditApptCommand editApptCommand = new EditApptCommand(
                 ALICE_APPT.getNric(),
                 new Date("1900-02-02"),
-                ALICE_APPT.getTimePeriod(),
+                ALICE_APPT.getStartTime(),
                 descriptor
         );
 
@@ -122,7 +121,7 @@ public class EditApptCommandTest {
         final EditApptCommand standardCommand = new EditApptCommand(
                 new Nric(VALID_NRIC_AMY),
                 new Date(VALID_APPOINTMENT_DATE_AMY),
-                new TimePeriod(new Time(VALID_APPOINTMENT_START_TIME_AMY), new Time(VALID_APPOINTMENT_END_TIME_AMY)),
+                new Time(VALID_APPOINTMENT_START_TIME_AMY),
                 descriptor);
 
         // same values -> returns true
@@ -130,7 +129,7 @@ public class EditApptCommandTest {
         EditApptCommand commandWithSameValues = new EditApptCommand(
                 new Nric(VALID_NRIC_AMY),
                 new Date(VALID_APPOINTMENT_DATE_AMY),
-                new TimePeriod(new Time(VALID_APPOINTMENT_START_TIME_AMY), new Time(VALID_APPOINTMENT_END_TIME_AMY)),
+                new Time(VALID_APPOINTMENT_START_TIME_AMY),
                 copyDescriptor);
         assertTrue(standardCommand.equals(commandWithSameValues));
 
@@ -147,7 +146,7 @@ public class EditApptCommandTest {
         assertFalse(standardCommand.equals(new EditApptCommand(
                 new Nric(VALID_NRIC_BOB),
                 new Date(VALID_APPOINTMENT_DATE_AMY),
-                new TimePeriod(new Time(VALID_APPOINTMENT_START_TIME_AMY), new Time(VALID_APPOINTMENT_END_TIME_AMY)),
+                new Time(VALID_APPOINTMENT_START_TIME_AMY),
                 descriptor)));
 
         final EditApptDescriptor diffDescriptor = new EditApptDescriptorBuilder()
@@ -157,7 +156,7 @@ public class EditApptCommandTest {
         assertFalse(standardCommand.equals(new EditApptCommand(
                 new Nric(VALID_NRIC_AMY),
                 new Date(VALID_APPOINTMENT_DATE_AMY),
-                new TimePeriod(new Time(VALID_APPOINTMENT_START_TIME_AMY), new Time(VALID_APPOINTMENT_END_TIME_AMY)),
+                new Time(VALID_APPOINTMENT_START_TIME_AMY),
                 diffDescriptor)));
     }
 
@@ -167,13 +166,12 @@ public class EditApptCommandTest {
         EditApptCommand editApptCommand = new EditApptCommand(
                 new Nric(VALID_NRIC_AMY),
                 new Date(VALID_APPOINTMENT_DATE_AMY),
-                new TimePeriod(new Time(VALID_APPOINTMENT_START_TIME_AMY), new Time(VALID_APPOINTMENT_END_TIME_AMY)),
+                new Time(VALID_APPOINTMENT_START_TIME_AMY),
                 editApptDescriptor);
         String expected = EditApptCommand.class.getCanonicalName()
                 + "{nric=" + VALID_NRIC_AMY
                 + ", date=" + VALID_APPOINTMENT_DATE_AMY
-                + ", timePeriod=" + VALID_APPOINTMENT_START_TIME_AMY
-                + " to " + VALID_APPOINTMENT_END_TIME_AMY
+                + ", startTime=" + VALID_APPOINTMENT_START_TIME_AMY
                 + ", editApptDescriptor=" + editApptDescriptor + "}";
         assertEquals(expected, editApptCommand.toString());
     }

--- a/src/test/java/seedu/address/logic/commands/EditApptDescriptorTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditApptDescriptorTest.java
@@ -41,9 +41,14 @@ public class EditApptDescriptorTest {
                 .withDate(VALID_APPOINTMENT_DATE_BOB).build();
         assertFalse(DESC_APPT_AMY.equals(editedAmyAppt));
 
-        // different timePeriod -> returns false
+        // different startTime -> returns false
         editedAmyAppt = new EditApptDescriptorBuilder(DESC_APPT_AMY)
-                .withTimePeriod(VALID_APPOINTMENT_START_TIME_BOB, VALID_APPOINTMENT_END_TIME_BOB).build();
+                .withStartTime(VALID_APPOINTMENT_START_TIME_BOB).build();
+        assertFalse(DESC_APPT_AMY.equals(editedAmyAppt));
+
+        // different endTime -> returns false
+        editedAmyAppt = new EditApptDescriptorBuilder(DESC_APPT_AMY)
+                .withEndTime(VALID_APPOINTMENT_END_TIME_BOB).build();
         assertFalse(DESC_APPT_AMY.equals(editedAmyAppt));
 
         // different appointmentType -> returns false
@@ -61,8 +66,9 @@ public class EditApptDescriptorTest {
     public void toStringMethod() {
         EditApptDescriptor editApptDescriptor = new EditApptDescriptor();
         String expected = EditApptDescriptor.class.getCanonicalName() + "{date="
-                + editApptDescriptor.getDate().orElse(null) + ", timePeriod="
-                + editApptDescriptor.getTimePeriod().orElse(null) + ", appointmentType="
+                + editApptDescriptor.getDate().orElse(null) + ", startTime="
+                + editApptDescriptor.getStartTime().orElse(null) + ", endTime="
+                + editApptDescriptor.getEndTime().orElse(null) + ", appointmentType="
                 + editApptDescriptor.getAppointmentType().orElse(null) + ", note="
                 + editApptDescriptor.getNote().orElse(null) + "}";
         assertEquals(expected, editApptDescriptor.toString());

--- a/src/test/java/seedu/address/logic/commands/MarkCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/MarkCommandTest.java
@@ -29,7 +29,7 @@ public class MarkCommandTest {
         MarkCommand markCommand = new MarkCommand(
                 ALICE_APPT.getNric(),
                 ALICE_APPT.getDate(),
-                ALICE_APPT.getTimePeriod()
+                ALICE_APPT.getStartTime()
         );
 
         // Expected message after successful mark
@@ -45,12 +45,12 @@ public class MarkCommandTest {
         MarkCommand markFirstAppointment = new MarkCommand(
                 ALICE_APPT.getNric(),
                 ALICE_APPT.getDate(),
-                ALICE_APPT.getTimePeriod()
+                ALICE_APPT.getStartTime()
         );
         MarkCommand markSecondAppointment = new MarkCommand(
                 ALICE_APPT_1.getNric(),
                 ALICE_APPT_1.getDate(),
-                ALICE_APPT_1.getTimePeriod()
+                ALICE_APPT_1.getStartTime()
         );
 
         // same object -> returns true
@@ -60,7 +60,7 @@ public class MarkCommandTest {
         MarkCommand markFirstAppointmentCopy = new MarkCommand(
                 ALICE_APPT.getNric(),
                 ALICE_APPT.getDate(),
-                ALICE_APPT.getTimePeriod()
+                ALICE_APPT.getStartTime()
         );
         assertTrue(markFirstAppointment.equals(markFirstAppointmentCopy));
 
@@ -80,13 +80,13 @@ public class MarkCommandTest {
         MarkCommand markCommand = new MarkCommand(
                 ALICE_APPT.getNric(),
                 ALICE_APPT.getDate(),
-                ALICE_APPT.getTimePeriod()
+                ALICE_APPT.getStartTime()
         );
 
         String expected = MarkCommand.class.getCanonicalName()
                 + "{nric=" + ALICE_APPT.getNric() + ", "
                 + "date=" + ALICE_APPT.getDate() + ", "
-                + "timePeriod=" + ALICE_APPT.getTimePeriod() + "}";
+                + "startTime=" + ALICE_APPT.getStartTime() + "}";
         assertEquals(expected, markCommand.toString());
     }
 

--- a/src/test/java/seedu/address/logic/commands/UnmarkCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/UnmarkCommandTest.java
@@ -29,7 +29,7 @@ public class UnmarkCommandTest {
         UnmarkCommand unmarkCommand = new UnmarkCommand(
                 ALICE_APPT_TRUE.getNric(),
                 ALICE_APPT_TRUE.getDate(),
-                ALICE_APPT_TRUE.getTimePeriod()
+                ALICE_APPT_TRUE.getStartTime()
         );
 
         // Expected message after successful unmark
@@ -45,12 +45,12 @@ public class UnmarkCommandTest {
         UnmarkCommand unmarkFirstAppointment = new UnmarkCommand(
                 ALICE_APPT_TRUE.getNric(),
                 ALICE_APPT_TRUE.getDate(),
-                ALICE_APPT_TRUE.getTimePeriod()
+                ALICE_APPT_TRUE.getStartTime()
         );
         UnmarkCommand unmarkSecondAppointment = new UnmarkCommand(
                 ALICE_APPT_1_TRUE.getNric(),
                 ALICE_APPT_1_TRUE.getDate(),
-                ALICE_APPT_1_TRUE.getTimePeriod()
+                ALICE_APPT_1_TRUE.getStartTime()
         );
 
         // same object -> returns true
@@ -60,7 +60,7 @@ public class UnmarkCommandTest {
         UnmarkCommand unmarkFirstAppointmentCopy = new UnmarkCommand(
                 ALICE_APPT_TRUE.getNric(),
                 ALICE_APPT_TRUE.getDate(),
-                ALICE_APPT_TRUE.getTimePeriod()
+                ALICE_APPT_TRUE.getStartTime()
         );
         assertTrue(unmarkFirstAppointment.equals(unmarkFirstAppointmentCopy));
 
@@ -80,13 +80,13 @@ public class UnmarkCommandTest {
         UnmarkCommand unmarkCommand = new UnmarkCommand(
                 ALICE_APPT_TRUE.getNric(),
                 ALICE_APPT_TRUE.getDate(),
-                ALICE_APPT_TRUE.getTimePeriod()
+                ALICE_APPT_TRUE.getStartTime()
         );
 
         String expected = UnmarkCommand.class.getCanonicalName()
                 + "{nric=" + ALICE_APPT_TRUE.getNric() + ", "
                 + "date=" + ALICE_APPT_TRUE.getDate() + ", "
-                + "timePeriod=" + ALICE_APPT_TRUE.getTimePeriod() + "}";
+                + "startTime=" + ALICE_APPT_TRUE.getStartTime() + "}";
         assertEquals(expected, unmarkCommand.toString());
     }
 

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -75,7 +75,7 @@ public class AddressBookParserTest {
         DeleteApptCommand command = (DeleteApptCommand) parser.parseCommand(AppointmentUtil
                 .getDeleteApptCommand(appt));
 
-        assertEquals(new DeleteApptCommand(appt.getNric(), appt.getDate(), appt.getTimePeriod()), command);
+        assertEquals(new DeleteApptCommand(appt.getNric(), appt.getDate(), appt.getStartTime()), command);
     }
 
     @Test
@@ -94,7 +94,7 @@ public class AddressBookParserTest {
         EditApptCommand command = (EditApptCommand) parser.parseCommand(EditApptCommand.COMMAND_WORD
                 + " " + AppointmentUtil.getAppointmentUniqueDetails(appt)
                 + " " + AppointmentUtil.getEditApptDescriptorDetails(descriptor));
-        assertEquals(new EditApptCommand(appt.getNric(), appt.getDate(), appt.getTimePeriod(), descriptor), command);
+        assertEquals(new EditApptCommand(appt.getNric(), appt.getDate(), appt.getStartTime(), descriptor), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/DeleteApptCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteApptCommandParserTest.java
@@ -2,17 +2,14 @@ package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.DATE_DESC_APPOINTMENT_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.END_TIME_DESC_APPOINTMENT_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_DATE_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_END_TIME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NRIC_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_START_TIME_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_TIME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.NRIC_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
 import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
 import static seedu.address.logic.commands.CommandTestUtil.START_TIME_DESC_APPOINTMENT_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_APPOINTMENT_DATE_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_APPOINTMENT_END_TIME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_APPOINTMENT_START_TIME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NRIC_BOB;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
@@ -24,7 +21,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.commons.core.date.Date;
 import seedu.address.logic.commands.DeleteApptCommand;
 import seedu.address.model.appointment.Appointment;
-import seedu.address.model.appointment.TimePeriod;
+import seedu.address.model.appointment.Time;
 import seedu.address.model.patient.Nric;
 import seedu.address.testutil.AppointmentBuilder;
 
@@ -38,11 +35,11 @@ public class DeleteApptCommandParserTest {
 
         // whitespace only preamble
         assertParseSuccess(parser, PREAMBLE_WHITESPACE + NRIC_DESC_BOB + DATE_DESC_APPOINTMENT_BOB
-                        + START_TIME_DESC_APPOINTMENT_BOB + END_TIME_DESC_APPOINTMENT_BOB,
+                        + START_TIME_DESC_APPOINTMENT_BOB,
                 new DeleteApptCommand(
                         expectedAppointment.getNric(),
                         expectedAppointment.getDate(),
-                        expectedAppointment.getTimePeriod()
+                        expectedAppointment.getStartTime()
                 ));
     }
 
@@ -51,28 +48,20 @@ public class DeleteApptCommandParserTest {
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteApptCommand.MESSAGE_USAGE);
 
         // missing NRIC prefix
-        assertParseFailure(parser, DATE_DESC_APPOINTMENT_BOB + START_TIME_DESC_APPOINTMENT_BOB
-                        + END_TIME_DESC_APPOINTMENT_BOB,
+        assertParseFailure(parser, DATE_DESC_APPOINTMENT_BOB + START_TIME_DESC_APPOINTMENT_BOB,
                 expectedMessage);
 
         // missing date prefix
-        assertParseFailure(parser, NRIC_DESC_BOB + START_TIME_DESC_APPOINTMENT_BOB
-                        + END_TIME_DESC_APPOINTMENT_BOB,
+        assertParseFailure(parser, NRIC_DESC_BOB + START_TIME_DESC_APPOINTMENT_BOB,
                 expectedMessage);
 
         // missing start time prefix
-        assertParseFailure(parser, NRIC_DESC_BOB + DATE_DESC_APPOINTMENT_BOB
-                        + END_TIME_DESC_APPOINTMENT_BOB,
-                expectedMessage);
-
-        // missing end time prefix
-        assertParseFailure(parser, NRIC_DESC_BOB + DATE_DESC_APPOINTMENT_BOB
-                        + START_TIME_DESC_APPOINTMENT_BOB,
+        assertParseFailure(parser, NRIC_DESC_BOB + DATE_DESC_APPOINTMENT_BOB,
                 expectedMessage);
 
         // all prefixes missing
         assertParseFailure(parser, VALID_NRIC_BOB + VALID_APPOINTMENT_DATE_BOB
-                        + VALID_APPOINTMENT_START_TIME_BOB + VALID_APPOINTMENT_END_TIME_BOB,
+                        + VALID_APPOINTMENT_START_TIME_BOB,
                 expectedMessage);
     }
 
@@ -80,23 +69,23 @@ public class DeleteApptCommandParserTest {
     public void parse_invalidValue_failure() {
         // invalid NRIC
         assertParseFailure(parser, INVALID_NRIC_DESC + DATE_DESC_APPOINTMENT_BOB
-                + START_TIME_DESC_APPOINTMENT_BOB + END_TIME_DESC_APPOINTMENT_BOB, Nric.MESSAGE_CONSTRAINTS);
+                + START_TIME_DESC_APPOINTMENT_BOB, Nric.MESSAGE_CONSTRAINTS);
 
         // invalid date
         assertParseFailure(parser, NRIC_DESC_BOB + INVALID_DATE_DESC
-                + START_TIME_DESC_APPOINTMENT_BOB + END_TIME_DESC_APPOINTMENT_BOB, Date.MESSAGE_CONSTRAINTS);
+                + START_TIME_DESC_APPOINTMENT_BOB, Date.MESSAGE_CONSTRAINTS);
 
-        // invalid time period
+        // invalid start time (as a time var)
         assertParseFailure(parser, NRIC_DESC_BOB + DATE_DESC_APPOINTMENT_BOB
-                + INVALID_START_TIME_DESC + INVALID_END_TIME_DESC, TimePeriod.MESSAGE_CONSTRAINTS);
+                + INVALID_TIME_DESC, Time.MESSAGE_CONSTRAINTS);
 
         // multiple invalid values, only the first one reported
         assertParseFailure(parser, INVALID_NRIC_DESC + INVALID_DATE_DESC
-                + START_TIME_DESC_APPOINTMENT_BOB + END_TIME_DESC_APPOINTMENT_BOB, Nric.MESSAGE_CONSTRAINTS);
+                + START_TIME_DESC_APPOINTMENT_BOB, Nric.MESSAGE_CONSTRAINTS);
 
         // non-empty preamble
         assertParseFailure(parser, PREAMBLE_NON_EMPTY + NRIC_DESC_BOB + DATE_DESC_APPOINTMENT_BOB
-                        + START_TIME_DESC_APPOINTMENT_BOB + END_TIME_DESC_APPOINTMENT_BOB,
+                        + START_TIME_DESC_APPOINTMENT_BOB,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteApptCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/EditApptCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditApptCommandParserTest.java
@@ -3,9 +3,7 @@ package seedu.address.logic.parser;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.DATE_DESC_APPOINTMENT_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.DESC_APPT_AMY;
-import static seedu.address.logic.commands.CommandTestUtil.END_TIME_DESC_APPOINTMENT_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_DATE_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_END_TIME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NEW_APPOINTMENT_TYPE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NEW_DATE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NEW_END_TIME_DESC;
@@ -49,7 +47,6 @@ import seedu.address.logic.commands.EditApptCommand;
 import seedu.address.logic.commands.EditApptCommand.EditApptDescriptor;
 import seedu.address.model.appointment.AppointmentType;
 import seedu.address.model.appointment.Time;
-import seedu.address.model.appointment.TimePeriod;
 import seedu.address.model.patient.Nric;
 import seedu.address.testutil.EditApptDescriptorBuilder;
 
@@ -63,25 +60,16 @@ public class EditApptCommandParserTest {
         // no nric specified
         assertParseFailure(parser, DATE_DESC_APPOINTMENT_AMY
                 + START_TIME_DESC_APPOINTMENT_AMY
-                + END_TIME_DESC_APPOINTMENT_AMY
                 + DESC_APPT_AMY, MESSAGE_INVALID_FORMAT);
 
         // no date specified
         assertParseFailure(parser, NRIC_DESC_AMY
                 + START_TIME_DESC_APPOINTMENT_AMY
-                + END_TIME_DESC_APPOINTMENT_AMY
                 + DESC_APPT_AMY, MESSAGE_INVALID_FORMAT);
 
         // no startTime specified
         assertParseFailure(parser, NRIC_DESC_AMY
                 + DATE_DESC_APPOINTMENT_AMY
-                + END_TIME_DESC_APPOINTMENT_AMY
-                + DESC_APPT_AMY, MESSAGE_INVALID_FORMAT);
-
-        // no endTime specified
-        assertParseFailure(parser, NRIC_DESC_AMY
-                + DATE_DESC_APPOINTMENT_AMY
-                + START_TIME_DESC_APPOINTMENT_AMY
                 + DESC_APPT_AMY, MESSAGE_INVALID_FORMAT);
 
         // no field specified
@@ -89,11 +77,10 @@ public class EditApptCommandParserTest {
                 parser,
                 NRIC_DESC_AMY
                 + DATE_DESC_APPOINTMENT_AMY
-                + START_TIME_DESC_APPOINTMENT_AMY
-                + END_TIME_DESC_APPOINTMENT_AMY,
+                + START_TIME_DESC_APPOINTMENT_AMY,
                 EditApptCommand.MESSAGE_EDIT_APPT_NO_FIELDS_FAILURE);
 
-        // no nric, date, startTime, endTime and fields specified
+        // no nric, date, startTime and fields specified
         assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
     }
 
@@ -105,7 +92,6 @@ public class EditApptCommandParserTest {
                 + NRIC_DESC_AMY
                 + DATE_DESC_APPOINTMENT_AMY
                 + START_TIME_DESC_APPOINTMENT_AMY
-                + END_TIME_DESC_APPOINTMENT_AMY
                 + DESC_APPT_AMY, MESSAGE_INVALID_FORMAT);
     }
 
@@ -114,37 +100,28 @@ public class EditApptCommandParserTest {
 
         String validTargetAppt = NRIC_DESC_AMY
                 + DATE_DESC_APPOINTMENT_AMY
-                + START_TIME_DESC_APPOINTMENT_AMY
-                + END_TIME_DESC_APPOINTMENT_AMY;
+                + START_TIME_DESC_APPOINTMENT_AMY;
 
         assertParseFailure(parser, INVALID_NRIC_DESC
                 + DATE_DESC_APPOINTMENT_AMY
                 + START_TIME_DESC_APPOINTMENT_AMY
-                + END_TIME_DESC_APPOINTMENT_AMY
                 + DESC_APPT_AMY, Nric.MESSAGE_CONSTRAINTS); // invalid nric
         assertParseFailure(parser, NRIC_DESC_AMY
                 + INVALID_DATE_DESC
                 + START_TIME_DESC_APPOINTMENT_AMY
-                + END_TIME_DESC_APPOINTMENT_AMY
                 + DESC_APPT_AMY, Date.MESSAGE_CONSTRAINTS); // invalid date
         assertParseFailure(parser, NRIC_DESC_AMY
                 + DATE_DESC_APPOINTMENT_AMY
                 + INVALID_START_TIME_DESC
-                + END_TIME_DESC_APPOINTMENT_AMY
                 + DESC_APPT_AMY, Time.MESSAGE_CONSTRAINTS); // invalid startTime
-        assertParseFailure(parser, NRIC_DESC_AMY
-                + DATE_DESC_APPOINTMENT_AMY
-                + START_TIME_DESC_APPOINTMENT_AMY
-                + INVALID_END_TIME_DESC
-                + DESC_APPT_AMY, Time.MESSAGE_CONSTRAINTS); // invalid endTime
 
         //More invalid tests here for the descriptors
         assertParseFailure(parser, validTargetAppt
                 + INVALID_NEW_DATE_DESC , Date.MESSAGE_CONSTRAINTS); // invalid new date
         assertParseFailure(parser, validTargetAppt
-                + INVALID_NEW_START_TIME_DESC , TimePeriod.MESSAGE_CONSTRAINTS); // invalid new startTime
+                + INVALID_NEW_START_TIME_DESC , Time.MESSAGE_CONSTRAINTS); // invalid new startTime
         assertParseFailure(parser, validTargetAppt
-                + INVALID_NEW_END_TIME_DESC , TimePeriod.MESSAGE_CONSTRAINTS); // invalid new endTime
+                + INVALID_NEW_END_TIME_DESC , Time.MESSAGE_CONSTRAINTS); // invalid new endTime
         assertParseFailure(parser, validTargetAppt
                 + INVALID_NEW_APPOINTMENT_TYPE_DESC , AppointmentType.MESSAGE_CONSTRAINTS); // invalid new apptType
 
@@ -154,7 +131,6 @@ public class EditApptCommandParserTest {
         assertParseFailure(parser, NRIC_DESC_AMY
                 + INVALID_DATE_DESC
                 + INVALID_START_TIME_DESC
-                + END_TIME_DESC_APPOINTMENT_AMY
                 + DESC_APPT_AMY, Date.MESSAGE_CONSTRAINTS);
     }
 
@@ -162,15 +138,11 @@ public class EditApptCommandParserTest {
     public void parse_allFieldsSpecified_success() {
         Nric targetNric = new Nric(VALID_NRIC_AMY);
         Date targetDate = new Date(VALID_APPOINTMENT_DATE_AMY);
-        TimePeriod targetTimePeriod = new TimePeriod(
-                new Time(VALID_APPOINTMENT_START_TIME_AMY),
-                new Time(VALID_APPOINTMENT_END_TIME_AMY)
-        );
+        Time targetStartTime = new Time(VALID_APPOINTMENT_START_TIME_AMY);
 
         String validTargetAppt = NRIC_DESC_AMY
                 + DATE_DESC_APPOINTMENT_AMY
-                + START_TIME_DESC_APPOINTMENT_AMY
-                + END_TIME_DESC_APPOINTMENT_AMY;
+                + START_TIME_DESC_APPOINTMENT_AMY;
 
         String userInput = validTargetAppt
                 + NEW_DATE_DESC_APPOINTMENT_BOB
@@ -180,10 +152,11 @@ public class EditApptCommandParserTest {
                 + NEW_NOTE_DESC_APPOINTMENT_BOB;
 
         EditApptDescriptor descriptor = new EditApptDescriptorBuilder().withDate(VALID_APPOINTMENT_DATE_BOB)
-                .withTimePeriod(VALID_APPOINTMENT_START_TIME_BOB, VALID_APPOINTMENT_END_TIME_BOB)
+                .withStartTime(VALID_APPOINTMENT_START_TIME_BOB)
+                .withEndTime(VALID_APPOINTMENT_END_TIME_BOB)
                 .withAppointmentType(VALID_APPOINTMENT_TYPE_BOB).withNote(VALID_APPOINTMENT_NOTE_BOB)
                 .build();
-        EditApptCommand expectedCommand = new EditApptCommand(targetNric, targetDate, targetTimePeriod, descriptor);
+        EditApptCommand expectedCommand = new EditApptCommand(targetNric, targetDate, targetStartTime, descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
     }
@@ -192,22 +165,18 @@ public class EditApptCommandParserTest {
     public void parse_someFieldsSpecified_success() {
         Nric targetNric = new Nric(VALID_NRIC_AMY);
         Date targetDate = new Date(VALID_APPOINTMENT_DATE_AMY);
-        TimePeriod targetTimePeriod = new TimePeriod(
-                new Time(VALID_APPOINTMENT_START_TIME_AMY),
-                new Time(VALID_APPOINTMENT_END_TIME_AMY)
-        );
+        Time targetStartTime = new Time(VALID_APPOINTMENT_START_TIME_AMY);
 
         String validTargetAppt = NRIC_DESC_AMY
                 + DATE_DESC_APPOINTMENT_AMY
-                + START_TIME_DESC_APPOINTMENT_AMY
-                + END_TIME_DESC_APPOINTMENT_AMY;
+                + START_TIME_DESC_APPOINTMENT_AMY;
 
         String userInput = validTargetAppt + NEW_TYPE_DESC_APPOINTMENT_BOB + NEW_NOTE_DESC_APPOINTMENT_AMY;
 
         EditApptCommand.EditApptDescriptor descriptor =
                 new EditApptDescriptorBuilder().withAppointmentType(VALID_APPOINTMENT_TYPE_BOB)
                         .withNote(VALID_APPOINTMENT_NOTE_AMY).build();
-        EditApptCommand expectedCommand = new EditApptCommand(targetNric, targetDate, targetTimePeriod, descriptor);
+        EditApptCommand expectedCommand = new EditApptCommand(targetNric, targetDate, targetStartTime, descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
     }
@@ -216,51 +185,45 @@ public class EditApptCommandParserTest {
     public void parse_oneFieldSpecified_success() {
         Nric targetNric = new Nric(VALID_NRIC_AMY);
         Date targetDate = new Date(VALID_APPOINTMENT_DATE_AMY);
-        TimePeriod targetTimePeriod = new TimePeriod(
-                new Time(VALID_APPOINTMENT_START_TIME_AMY),
-                new Time(VALID_APPOINTMENT_END_TIME_AMY)
-        );
+        Time targetStartTime = new Time(VALID_APPOINTMENT_START_TIME_AMY);
 
         String validTargetAppt = NRIC_DESC_AMY
                 + DATE_DESC_APPOINTMENT_AMY
-                + START_TIME_DESC_APPOINTMENT_AMY
-                + END_TIME_DESC_APPOINTMENT_AMY;
+                + START_TIME_DESC_APPOINTMENT_AMY;
 
         String userInput = validTargetAppt + NEW_NOTE_DESC_APPOINTMENT_BOB;
         EditApptDescriptor descriptor = new EditApptDescriptorBuilder().withNote(VALID_APPOINTMENT_NOTE_BOB).build();
-        EditApptCommand expectedCommand = new EditApptCommand(targetNric, targetDate, targetTimePeriod, descriptor);
+        EditApptCommand expectedCommand = new EditApptCommand(targetNric, targetDate, targetStartTime, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // date
         userInput = validTargetAppt + NEW_DATE_DESC_APPOINTMENT_BOB;
         descriptor = new EditApptDescriptorBuilder().withDate(VALID_APPOINTMENT_DATE_BOB).build();
-        expectedCommand = new EditApptCommand(targetNric, targetDate, targetTimePeriod, descriptor);
+        expectedCommand = new EditApptCommand(targetNric, targetDate, targetStartTime, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         // startTime
         userInput = validTargetAppt + NEW_START_TIME_DESC_APPOINTMENT_AMY;
-        descriptor = new EditApptDescriptorBuilder().withTimePeriod(VALID_APPOINTMENT_START_TIME_AMY,
-                VALID_APPOINTMENT_END_TIME_AMY).build();
-        expectedCommand = new EditApptCommand(targetNric, targetDate, targetTimePeriod, descriptor);
+        descriptor = new EditApptDescriptorBuilder().withStartTime(VALID_APPOINTMENT_START_TIME_AMY).build();
+        expectedCommand = new EditApptCommand(targetNric, targetDate, targetStartTime, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         //endTime
         userInput = validTargetAppt + NEW_END_TIME_DESC_APPOINTMENT_AMY;
-        descriptor = new EditApptDescriptorBuilder().withTimePeriod(VALID_APPOINTMENT_START_TIME_AMY,
-                VALID_APPOINTMENT_END_TIME_AMY).build();
-        expectedCommand = new EditApptCommand(targetNric, targetDate, targetTimePeriod, descriptor);
+        descriptor = new EditApptDescriptorBuilder().withEndTime(VALID_APPOINTMENT_END_TIME_AMY).build();
+        expectedCommand = new EditApptCommand(targetNric, targetDate, targetStartTime, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         //appointmentType
         userInput = validTargetAppt + NEW_TYPE_DESC_APPOINTMENT_BOB;
         descriptor = new EditApptDescriptorBuilder().withAppointmentType(VALID_APPOINTMENT_TYPE_BOB).build();
-        expectedCommand = new EditApptCommand(targetNric, targetDate, targetTimePeriod, descriptor);
+        expectedCommand = new EditApptCommand(targetNric, targetDate, targetStartTime, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
 
         //note
         userInput = validTargetAppt + NEW_NOTE_DESC_APPOINTMENT_BOB;
         descriptor = new EditApptDescriptorBuilder().withNote(VALID_APPOINTMENT_NOTE_BOB).build();
-        expectedCommand = new EditApptCommand(targetNric, targetDate, targetTimePeriod, descriptor);
+        expectedCommand = new EditApptCommand(targetNric, targetDate, targetStartTime, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
     }
 
@@ -271,15 +234,11 @@ public class EditApptCommandParserTest {
 
         String validTargetAppt = NRIC_DESC_AMY
                 + DATE_DESC_APPOINTMENT_AMY
-                + START_TIME_DESC_APPOINTMENT_AMY
-                + END_TIME_DESC_APPOINTMENT_AMY;
+                + START_TIME_DESC_APPOINTMENT_AMY;
 
         Nric targetNric = new Nric(VALID_NRIC_AMY);
         Date targetDate = new Date(VALID_APPOINTMENT_DATE_AMY);
-        TimePeriod targetTimePeriod = new TimePeriod(
-                new Time(VALID_APPOINTMENT_START_TIME_AMY),
-                new Time(VALID_APPOINTMENT_END_TIME_AMY)
-        );
+        Time targetStartTime = new Time(VALID_APPOINTMENT_START_TIME_AMY);
 
         // invalid followed by valid
         String userInput = validTargetAppt + INVALID_NEW_DATE_DESC + NEW_DATE_DESC_APPOINTMENT_AMY;

--- a/src/test/java/seedu/address/logic/parser/MarkCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/MarkCommandParserTest.java
@@ -2,17 +2,14 @@ package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.DATE_DESC_APPOINTMENT_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.END_TIME_DESC_APPOINTMENT_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_DATE_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_END_TIME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NRIC_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_START_TIME_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_TIME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.NRIC_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
 import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
 import static seedu.address.logic.commands.CommandTestUtil.START_TIME_DESC_APPOINTMENT_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_APPOINTMENT_DATE_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_APPOINTMENT_END_TIME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_APPOINTMENT_START_TIME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NRIC_BOB;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
@@ -24,7 +21,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.commons.core.date.Date;
 import seedu.address.logic.commands.MarkCommand;
 import seedu.address.model.appointment.Appointment;
-import seedu.address.model.appointment.TimePeriod;
+import seedu.address.model.appointment.Time;
 import seedu.address.model.patient.Nric;
 import seedu.address.testutil.AppointmentBuilder;
 
@@ -38,11 +35,11 @@ public class MarkCommandParserTest {
 
         // whitespace only preamble
         assertParseSuccess(parser, PREAMBLE_WHITESPACE + NRIC_DESC_BOB + DATE_DESC_APPOINTMENT_BOB
-                        + START_TIME_DESC_APPOINTMENT_BOB + END_TIME_DESC_APPOINTMENT_BOB,
+                        + START_TIME_DESC_APPOINTMENT_BOB,
                 new MarkCommand(
                         expectedAppointment.getNric(),
                         expectedAppointment.getDate(),
-                        expectedAppointment.getTimePeriod()
+                        expectedAppointment.getStartTime()
                 ));
     }
 
@@ -51,28 +48,20 @@ public class MarkCommandParserTest {
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, MarkCommand.MESSAGE_USAGE);
 
         // missing NRIC prefix
-        assertParseFailure(parser, DATE_DESC_APPOINTMENT_BOB + START_TIME_DESC_APPOINTMENT_BOB
-                        + END_TIME_DESC_APPOINTMENT_BOB,
+        assertParseFailure(parser, DATE_DESC_APPOINTMENT_BOB + START_TIME_DESC_APPOINTMENT_BOB,
                 expectedMessage);
 
         // missing date prefix
-        assertParseFailure(parser, NRIC_DESC_BOB + START_TIME_DESC_APPOINTMENT_BOB
-                        + END_TIME_DESC_APPOINTMENT_BOB,
+        assertParseFailure(parser, NRIC_DESC_BOB + START_TIME_DESC_APPOINTMENT_BOB,
                 expectedMessage);
 
         // missing start time prefix
-        assertParseFailure(parser, NRIC_DESC_BOB + DATE_DESC_APPOINTMENT_BOB
-                        + END_TIME_DESC_APPOINTMENT_BOB,
-                expectedMessage);
-
-        // missing end time prefix
-        assertParseFailure(parser, NRIC_DESC_BOB + DATE_DESC_APPOINTMENT_BOB
-                        + START_TIME_DESC_APPOINTMENT_BOB,
+        assertParseFailure(parser, NRIC_DESC_BOB + DATE_DESC_APPOINTMENT_BOB,
                 expectedMessage);
 
         // all prefixes missing
         assertParseFailure(parser, VALID_NRIC_BOB + VALID_APPOINTMENT_DATE_BOB
-                        + VALID_APPOINTMENT_START_TIME_BOB + VALID_APPOINTMENT_END_TIME_BOB,
+                        + VALID_APPOINTMENT_START_TIME_BOB,
                 expectedMessage);
     }
 
@@ -80,23 +69,23 @@ public class MarkCommandParserTest {
     public void parse_invalidValue_failure() {
         // invalid NRIC
         assertParseFailure(parser, INVALID_NRIC_DESC + DATE_DESC_APPOINTMENT_BOB
-                + START_TIME_DESC_APPOINTMENT_BOB + END_TIME_DESC_APPOINTMENT_BOB, Nric.MESSAGE_CONSTRAINTS);
+                + START_TIME_DESC_APPOINTMENT_BOB, Nric.MESSAGE_CONSTRAINTS);
 
         // invalid date
         assertParseFailure(parser, NRIC_DESC_BOB + INVALID_DATE_DESC
-                + START_TIME_DESC_APPOINTMENT_BOB + END_TIME_DESC_APPOINTMENT_BOB, Date.MESSAGE_CONSTRAINTS);
+                + START_TIME_DESC_APPOINTMENT_BOB, Date.MESSAGE_CONSTRAINTS);
 
-        // invalid time period
+        // invalid start time (as a time var)
         assertParseFailure(parser, NRIC_DESC_BOB + DATE_DESC_APPOINTMENT_BOB
-                + INVALID_START_TIME_DESC + INVALID_END_TIME_DESC, TimePeriod.MESSAGE_CONSTRAINTS);
+                + INVALID_TIME_DESC, Time.MESSAGE_CONSTRAINTS);
 
         // multiple invalid values, only the first one reported
         assertParseFailure(parser, INVALID_NRIC_DESC + INVALID_DATE_DESC
-                + START_TIME_DESC_APPOINTMENT_BOB + END_TIME_DESC_APPOINTMENT_BOB, Nric.MESSAGE_CONSTRAINTS);
+                + START_TIME_DESC_APPOINTMENT_BOB, Nric.MESSAGE_CONSTRAINTS);
 
         // non-empty preamble
         assertParseFailure(parser, PREAMBLE_NON_EMPTY + NRIC_DESC_BOB + DATE_DESC_APPOINTMENT_BOB
-                        + START_TIME_DESC_APPOINTMENT_BOB + END_TIME_DESC_APPOINTMENT_BOB,
+                        + START_TIME_DESC_APPOINTMENT_BOB,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, MarkCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/UnmarkCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/UnmarkCommandParserTest.java
@@ -2,17 +2,14 @@ package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.DATE_DESC_APPOINTMENT_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.END_TIME_DESC_APPOINTMENT_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_DATE_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_END_TIME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NRIC_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_START_TIME_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_TIME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.NRIC_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
 import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
 import static seedu.address.logic.commands.CommandTestUtil.START_TIME_DESC_APPOINTMENT_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_APPOINTMENT_DATE_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_APPOINTMENT_END_TIME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_APPOINTMENT_START_TIME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NRIC_BOB;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
@@ -24,7 +21,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.commons.core.date.Date;
 import seedu.address.logic.commands.UnmarkCommand;
 import seedu.address.model.appointment.Appointment;
-import seedu.address.model.appointment.TimePeriod;
+import seedu.address.model.appointment.Time;
 import seedu.address.model.patient.Nric;
 import seedu.address.testutil.AppointmentBuilder;
 
@@ -38,11 +35,11 @@ public class UnmarkCommandParserTest {
 
         // whitespace only preamble
         assertParseSuccess(parser, PREAMBLE_WHITESPACE + NRIC_DESC_BOB + DATE_DESC_APPOINTMENT_BOB
-                        + START_TIME_DESC_APPOINTMENT_BOB + END_TIME_DESC_APPOINTMENT_BOB,
+                        + START_TIME_DESC_APPOINTMENT_BOB,
                 new UnmarkCommand(
                         expectedAppointment.getNric(),
                         expectedAppointment.getDate(),
-                        expectedAppointment.getTimePeriod()
+                        expectedAppointment.getStartTime()
                 ));
     }
 
@@ -51,28 +48,20 @@ public class UnmarkCommandParserTest {
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnmarkCommand.MESSAGE_USAGE);
 
         // missing NRIC prefix
-        assertParseFailure(parser, DATE_DESC_APPOINTMENT_BOB + START_TIME_DESC_APPOINTMENT_BOB
-                        + END_TIME_DESC_APPOINTMENT_BOB,
+        assertParseFailure(parser, DATE_DESC_APPOINTMENT_BOB + START_TIME_DESC_APPOINTMENT_BOB,
                 expectedMessage);
 
         // missing date prefix
-        assertParseFailure(parser, NRIC_DESC_BOB + START_TIME_DESC_APPOINTMENT_BOB
-                        + END_TIME_DESC_APPOINTMENT_BOB,
+        assertParseFailure(parser, NRIC_DESC_BOB + START_TIME_DESC_APPOINTMENT_BOB,
                 expectedMessage);
 
         // missing start time prefix
-        assertParseFailure(parser, NRIC_DESC_BOB + DATE_DESC_APPOINTMENT_BOB
-                        + END_TIME_DESC_APPOINTMENT_BOB,
-                expectedMessage);
-
-        // missing end time prefix
-        assertParseFailure(parser, NRIC_DESC_BOB + DATE_DESC_APPOINTMENT_BOB
-                        + START_TIME_DESC_APPOINTMENT_BOB,
+        assertParseFailure(parser, NRIC_DESC_BOB + DATE_DESC_APPOINTMENT_BOB,
                 expectedMessage);
 
         // all prefixes missing
         assertParseFailure(parser, VALID_NRIC_BOB + VALID_APPOINTMENT_DATE_BOB
-                        + VALID_APPOINTMENT_START_TIME_BOB + VALID_APPOINTMENT_END_TIME_BOB,
+                        + VALID_APPOINTMENT_START_TIME_BOB,
                 expectedMessage);
     }
 
@@ -80,23 +69,23 @@ public class UnmarkCommandParserTest {
     public void parse_invalidValue_failure() {
         // invalid NRIC
         assertParseFailure(parser, INVALID_NRIC_DESC + DATE_DESC_APPOINTMENT_BOB
-                + START_TIME_DESC_APPOINTMENT_BOB + END_TIME_DESC_APPOINTMENT_BOB, Nric.MESSAGE_CONSTRAINTS);
+                + START_TIME_DESC_APPOINTMENT_BOB, Nric.MESSAGE_CONSTRAINTS);
 
         // invalid date
         assertParseFailure(parser, NRIC_DESC_BOB + INVALID_DATE_DESC
-                + START_TIME_DESC_APPOINTMENT_BOB + END_TIME_DESC_APPOINTMENT_BOB, Date.MESSAGE_CONSTRAINTS);
+                + START_TIME_DESC_APPOINTMENT_BOB, Date.MESSAGE_CONSTRAINTS);
 
-        // invalid time period
+        // invalid start time (as a time var)
         assertParseFailure(parser, NRIC_DESC_BOB + DATE_DESC_APPOINTMENT_BOB
-                + INVALID_START_TIME_DESC + INVALID_END_TIME_DESC, TimePeriod.MESSAGE_CONSTRAINTS);
+                + INVALID_TIME_DESC, Time.MESSAGE_CONSTRAINTS);
 
         // multiple invalid values, only the first one reported
         assertParseFailure(parser, INVALID_NRIC_DESC + INVALID_DATE_DESC
-                + START_TIME_DESC_APPOINTMENT_BOB + END_TIME_DESC_APPOINTMENT_BOB, Nric.MESSAGE_CONSTRAINTS);
+                + START_TIME_DESC_APPOINTMENT_BOB, Nric.MESSAGE_CONSTRAINTS);
 
         // non-empty preamble
         assertParseFailure(parser, PREAMBLE_NON_EMPTY + NRIC_DESC_BOB + DATE_DESC_APPOINTMENT_BOB
-                        + START_TIME_DESC_APPOINTMENT_BOB + END_TIME_DESC_APPOINTMENT_BOB,
+                        + START_TIME_DESC_APPOINTMENT_BOB,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, UnmarkCommand.MESSAGE_USAGE));
     }
 }

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -285,7 +285,7 @@ public class ModelManagerTest {
         Appointment matchingAppointment = modelManager.getMatchingAppointment(
                 ALICE_APPT.getNric(),
                 ALICE_APPT.getDate(),
-                ALICE_APPT.getTimePeriod()
+                ALICE_APPT.getStartTime()
         );
 
         assertEquals(appointment, matchingAppointment);

--- a/src/test/java/seedu/address/model/appointment/AppointmentListTest.java
+++ b/src/test/java/seedu/address/model/appointment/AppointmentListTest.java
@@ -282,8 +282,7 @@ public class AppointmentListTest {
         assertThrows(NullPointerException.class, () -> appointmentList.hasAppointmentWithDetails(
                 null, null, null)
         );
-    }  
-  
+    }
     @Test
     public void samePatientHasOverlappingAppointment_noOverlap_returnsFalse() {
         // Appointments have no overlapping time periods

--- a/src/test/java/seedu/address/model/appointment/AppointmentListTest.java
+++ b/src/test/java/seedu/address/model/appointment/AppointmentListTest.java
@@ -180,9 +180,9 @@ public class AppointmentListTest {
         appointmentList.add(ALICE_APPT);
         Nric nricToMatch = ALICE_APPT.getNric();
         Date dateToMatch = ALICE_APPT.getDate();
-        TimePeriod timePeriodToMatch = ALICE_APPT.getTimePeriod();
+        Time startTimeToMatch = ALICE_APPT.getStartTime();
 
-        assertEquals(ALICE_APPT, appointmentList.getMatchingAppointment(nricToMatch, dateToMatch, timePeriodToMatch));
+        assertEquals(ALICE_APPT, appointmentList.getMatchingAppointment(nricToMatch, dateToMatch, startTimeToMatch));
     }
 
     @Test
@@ -190,15 +190,17 @@ public class AppointmentListTest {
         appointmentList.add(ALICE_APPT);
         Nric nricToMatch = ALICE_APPT_1.getNric();
         Date dateToMatch = ALICE_APPT_1.getDate();
-        TimePeriod timePeriodToMatch = ALICE_APPT_1.getTimePeriod();
+        Time startTimeToMatch = ALICE_APPT_1.getStartTime();
 
         assertThrows(AppointmentNotFoundException.class, () ->
-                appointmentList.getMatchingAppointment(nricToMatch, dateToMatch, timePeriodToMatch));
+                appointmentList.getMatchingAppointment(nricToMatch, dateToMatch, startTimeToMatch));
     }
 
     @Test
     public void getMatchingAppointment_nullInput_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> appointmentList.getMatchingAppointment(null, null, null));
+        assertThrows(NullPointerException.class, () -> appointmentList.getMatchingAppointment(
+                null, null, null)
+        );
     }
 
     @Test
@@ -231,6 +233,28 @@ public class AppointmentListTest {
     @Test
     public void deleteAppointmentsWithNric_nullNric_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> appointmentList.deleteAppointmentsWithNric(null));
+    }
+
+    @Test
+    public void hasAppointmentWithDetails_existingAppointment_returnsTrue() {
+        appointmentList.add(ALICE_APPT);
+        assertTrue(appointmentList.hasAppointmentWithDetails(
+                ALICE_APPT.getNric(), ALICE_APPT.getDate(), ALICE_APPT.getStartTime())
+        );
+    }
+
+    @Test
+    public void hasAppointmentWithDetails_nonExistingAppointment_returnsFalse() {
+        assertFalse(appointmentList.hasAppointmentWithDetails(
+                ALICE_APPT.getNric(), ALICE_APPT.getDate(), ALICE_APPT.getStartTime())
+        );
+    }
+
+    @Test
+    public void hasAppointmentWithDetails_nullParameters_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> appointmentList.hasAppointmentWithDetails(
+                null, null, null)
+        );
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/AppointmentUtil.java
+++ b/src/test/java/seedu/address/testutil/AppointmentUtil.java
@@ -52,13 +52,13 @@ public class AppointmentUtil {
 
     /**
      * Returns the part of command string that uniquely identifies the given {@code appointment}.
+     * It has since been modified to be only Nric, Date and StartTime.
      */
     public static String getAppointmentUniqueDetails(Appointment appointment) {
         StringBuilder sb = new StringBuilder();
         sb.append(PREFIX_NRIC + appointment.getNric().value + " ");
         sb.append(PREFIX_DATE + appointment.getDate().toString() + " ");
         sb.append(PREFIX_START_TIME + appointment.getStartTime().toString() + " ");
-        sb.append(PREFIX_END_TIME + appointment.getEndTime().toString() + " ");
         return sb.toString();
     }
 
@@ -68,10 +68,9 @@ public class AppointmentUtil {
     public static String getEditApptDescriptorDetails(EditApptCommand.EditApptDescriptor descriptor) {
         StringBuilder sb = new StringBuilder();
         descriptor.getDate().ifPresent(date -> sb.append(PREFIX_NEW_DATE).append(date.value).append(" "));
-        descriptor.getTimePeriod().ifPresent(timePeriod -> {
-            sb.append(PREFIX_NEW_START_TIME).append(timePeriod.getStartTime().value).append(" ");
-            sb.append(PREFIX_NEW_END_TIME).append(timePeriod.getEndTime().value).append(" ");
-        });
+        descriptor.getStartTime().ifPresent(startTime -> sb.append(PREFIX_NEW_START_TIME)
+                .append(startTime.value).append(" "));
+        descriptor.getEndTime().ifPresent(endTime -> sb.append(PREFIX_NEW_END_TIME).append(endTime.value).append(" "));
         descriptor.getAppointmentType().ifPresent(appointmentType -> sb.append(PREFIX_NEW_TAG)
                 .append(appointmentType.typeName).append(" "));
         descriptor.getNote().ifPresent(note -> sb.append(PREFIX_NEW_NOTE).append(note).append(" "));

--- a/src/test/java/seedu/address/testutil/EditApptDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditApptDescriptorBuilder.java
@@ -6,7 +6,6 @@ import seedu.address.model.appointment.Appointment;
 import seedu.address.model.appointment.AppointmentType;
 import seedu.address.model.appointment.Note;
 import seedu.address.model.appointment.Time;
-import seedu.address.model.appointment.TimePeriod;
 
 /**
  * A utility class to help with building EditApptDescriptor objects.
@@ -29,7 +28,8 @@ public class EditApptDescriptorBuilder {
     public EditApptDescriptorBuilder(Appointment appointment) {
         descriptor = new EditApptDescriptor();
         descriptor.setDate(appointment.getDate());
-        descriptor.setTimePeriod(appointment.getTimePeriod());
+        descriptor.setStartTime(appointment.getStartTime());
+        descriptor.setEndTime(appointment.getEndTime());
         descriptor.setAppointmentType(appointment.getAppointmentType());
         descriptor.setNote(appointment.getNote());
     }
@@ -43,10 +43,18 @@ public class EditApptDescriptorBuilder {
     }
 
     /**
-     * Sets the {@code TimePeriod} of the {@code EditApptDescriptor} that we are building.
+     * Sets the {@code StartTime} of the {@code EditApptDescriptor} that we are building.
      */
-    public EditApptDescriptorBuilder withTimePeriod(String startTime, String endTime) {
-        descriptor.setTimePeriod(new TimePeriod(new Time(startTime), new Time(endTime)));
+    public EditApptDescriptorBuilder withStartTime(String startTime) {
+        descriptor.setStartTime(new Time(startTime));
+        return this;
+    }
+
+    /**
+     * Sets the {@code EndTime} of the {@code EditApptDescriptor} that we are building.
+     */
+    public EditApptDescriptorBuilder withEndTime(String endTime) {
+        descriptor.setEndTime(new Time(endTime));
         return this;
     }
 


### PR DESCRIPTION
Remove the need to write a to/END_TIME for DeleteAppt, EditAppt, Mark and Unmark commands.

Tests have been updated to no longer require this end_time as well. Some changes made to getMatchingAppointment. 

Created hasAppointmentWithDetails method to check if appointment is present, so no longer need a mockAppointment to check within the above command classes. 

Will update documentation accordingly. 