### PR TITLE
Improve error messages for commands

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddApptCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddApptCommand.java
@@ -14,7 +14,6 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.appointment.Appointment;
 import seedu.address.model.patient.Nric;
-import seedu.address.ui.ViewMode;
 
 
 /**

--- a/src/main/java/seedu/address/logic/commands/AddApptCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddApptCommand.java
@@ -14,6 +14,7 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.appointment.Appointment;
 import seedu.address.model.patient.Nric;
+import seedu.address.ui.ViewMode;
 
 
 /**
@@ -26,7 +27,7 @@ public class AddApptCommand extends Command {
     public static final String COMMAND_WORD_ALT = "aa";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Adds an appointment for the patient identified by the NRIC given. \n"
+            + ": Adds an appointment, for the patient identified by the given NRIC, to the CLInic. \n"
             + "Parameters: "
             + PREFIX_NRIC + "NRIC "
             + PREFIX_DATE + "DATE "
@@ -46,8 +47,9 @@ public class AddApptCommand extends Command {
     public static final String MESSAGE_ADD_DUPLICATE_APPOINTMENT_FAILURE =
             "This appointment already exists in CLInic";
     public static final String MESSAGE_ADD_OVERLAPPING_APPOINTMENT_FAILURE =
-            "This appointment overlaps with an existing appointment for the same patient.\n"
-                    + "Please refer to appointments listed below for that patient on the same date.";
+            "New appointment overlaps with an existing appointment for the same patient.\n"
+                    + "Please refer to the Overall-View for the list of appointments "
+                    + "for that patient on the same date.";
 
     private final Appointment apptToAdd;
 

--- a/src/main/java/seedu/address/logic/commands/AddPatientCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddPatientCommand.java
@@ -24,10 +24,10 @@ public class AddPatientCommand extends Command {
 
     public static final String COMMAND_WORD_ALT = "ap";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a patient to the CLInic. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a patient to the CLInic. \n"
             + "Parameters: "
-            + PREFIX_NAME + "NAME "
             + PREFIX_NRIC + "NRIC "
+            + PREFIX_NAME + "NAME "
             + PREFIX_DOB + "DOB "
             + PREFIX_PHONE + "PHONE "
             + PREFIX_EMAIL + "EMAIL "

--- a/src/main/java/seedu/address/logic/commands/DeleteApptCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteApptCommand.java
@@ -24,7 +24,7 @@ public class DeleteApptCommand extends Command {
     public static final String COMMAND_WORD_ALT = "da";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Deletes the appointment identified by the NRIC, date, and start time given.\n"
+            + ": Deletes the appointment, identified by the given NRIC, date, and start time, from CLInic.\n"
             + "Parameters: "
             + PREFIX_NRIC + "NRIC "
             + PREFIX_DATE + "DATE "

--- a/src/main/java/seedu/address/logic/commands/DeletePatientCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeletePatientCommand.java
@@ -19,7 +19,7 @@ public class DeletePatientCommand extends Command {
     public static final String COMMAND_WORD_ALT = "dp";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Deletes the patient identified by the NRIC number.\n"
+            + ": Deletes the patient, identified by the given NRIC, from CLInic.\n"
             + "Parameters: "
             + PREFIX_NRIC + " NRIC (must be a existing NRIC in database)\n"
             + "Example: " + COMMAND_WORD + " " + PREFIX_NRIC + " S1234567A";

--- a/src/main/java/seedu/address/logic/commands/EditApptCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditApptCommand.java
@@ -37,10 +37,10 @@ public class EditApptCommand extends Command {
     public static final String COMMAND_WORD_ALT = "ea";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Edits the details of the appointment identified by its Nric, Date, and Start time.\n"
+            + ": Edits the details of the appointment, identified by the given NRIC, date, and start time, in CLInic.\n"
             + "Existing values will be overwritten by the input values.\n"
             + "Parameters: "
-            + PREFIX_NRIC + "NRIC (must be a valid NRIC in the system) "
+            + PREFIX_NRIC + "NRIC "
             + PREFIX_DATE + "DATE "
             + PREFIX_START_TIME + "START_TIME "
             + "[" + PREFIX_NEW_DATE + "NEW_DATE] "
@@ -60,8 +60,9 @@ public class EditApptCommand extends Command {
     public static final String MESSAGE_EDIT_APPT_NO_FIELDS_FAILURE = "At least one field to edit must be provided.";
 
     public static final String MESSAGE_EDIT_OVERLAPPING_APPOINTMENT_FAILURE =
-            "New appointment information overlaps with an existing appointment for the same patient.\n"
-                    + "Please refer to appointments listed below for that patient on the same date.";
+            "Edited appointment information overlaps with an existing appointment for the same patient.\n"
+                    + "Please refer to the Overall-View for the list of appointments "
+                    + "for that patient on the same date.";
 
     private final Nric targetNric;
     private final Date targetDate;

--- a/src/main/java/seedu/address/logic/commands/EditPatientCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditPatientCommand.java
@@ -40,7 +40,7 @@ public class EditPatientCommand extends Command {
     public static final String COMMAND_WORD_ALT = "ep";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Edits the details of the patient identified by their Nric number. "
+            + ": Edits the details of the patient, identified by the given NRIC, in CLInic. \n"
             + "Existing values will be overwritten by the input values.\n"
             + "Parameters: "
             + PREFIX_NRIC + " NRIC "

--- a/src/main/java/seedu/address/logic/commands/FindApptCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindApptCommand.java
@@ -22,8 +22,9 @@ public class FindApptCommand extends Command {
     public static final String COMMAND_WORD_ALT = "fa";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Finds the details of the appointment identified either by patient's NRIC, Date, or Start time.\n"
-            + "Parameters: "
+            + ": Finds the details of the appointment(s) with the given NRIC, on the given date, \n"
+            + "starting on or after the given start time or any combination of these three options.\n"
+            + "Parameters (at least one): "
             + "[" + PREFIX_NRIC + " NRIC] "
             + "[" + PREFIX_NAME + "DATE] "
             + "[" + PREFIX_START_TIME + "START_TIME]\n"

--- a/src/main/java/seedu/address/logic/commands/FindPatientCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindPatientCommand.java
@@ -23,8 +23,9 @@ public class FindPatientCommand extends Command {
     public static final String COMMAND_WORD_ALT = "fp";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Finds all patients whose names OR nric start with "
-            + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
+            + ": Finds all patient(s) by either name keyword(s) or NRIC keyword, not both. \n"
+            + "Specified keywords are case-insensitive and a match is achieved "
+            + "when the start of any word in the name or NRIC matches the keyword. \n"
             + "Parameters: "
             + PREFIX_NAME + "NAME_KEYWORD [MORE_NAME_KEYWORDS] OR "
             + PREFIX_NRIC + "NRIC_KEYWORD \n"

--- a/src/main/java/seedu/address/logic/commands/MarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkCommand.java
@@ -24,7 +24,7 @@ public class MarkCommand extends Command {
     public static final String COMMAND_WORD = "mark";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Mark the appointment of the patient identified as completed\n"
+            + ": Marks the appointment, identified by the given NRIC, date, and start time, in CLInic.\n"
             + "Parameters: "
             + PREFIX_NRIC + "NRIC "
             + PREFIX_DATE + "DATE "

--- a/src/main/java/seedu/address/logic/commands/UnmarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnmarkCommand.java
@@ -24,7 +24,7 @@ public class UnmarkCommand extends Command {
     public static final String COMMAND_WORD = "unmark";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Unmark the appointment of the patient identified as not completed\n"
+            + ": Unmarks the appointment, identified by the given NRIC, date, and start time, in CLInic.\n"
             + "Parameters: "
             + PREFIX_NRIC + "NRIC "
             + PREFIX_DATE + "DATE "

--- a/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
+++ b/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
@@ -9,7 +9,6 @@ import seedu.address.model.patient.Patient;
  * Unmodifiable view of an address book
  */
 public interface ReadOnlyAddressBook {
-
     /**
      * Returns an unmodifiable view of the patients list.
      * This list will not contain any duplicate patients.

--- a/src/main/java/seedu/address/model/UserPrefs.java
+++ b/src/main/java/seedu/address/model/UserPrefs.java
@@ -14,7 +14,7 @@ import seedu.address.commons.core.GuiSettings;
 public class UserPrefs implements ReadOnlyUserPrefs {
 
     private GuiSettings guiSettings = new GuiSettings();
-    private Path addressBookFilePath = Paths.get("data" , "addressbook.json");
+    private Path addressBookFilePath = Paths.get("data" , "CLInic.json");
 
     /**
      * Creates a {@code UserPrefs} with default values.

--- a/src/main/java/seedu/address/model/appointment/Time.java
+++ b/src/main/java/seedu/address/model/appointment/Time.java
@@ -40,6 +40,12 @@ public class Time implements Comparable<Time> {
      * Returns if a given string is a valid time.
      */
     public static boolean isValidTime(String test) {
+        requireNonNull(test);
+        try {
+            LocalTime.parse(test);
+        } catch (Exception e) {
+            return false;
+        }
         return test.matches(VALIDATION_REGEX);
     }
 

--- a/src/main/java/seedu/address/model/patient/Name.java
+++ b/src/main/java/seedu/address/model/patient/Name.java
@@ -12,7 +12,7 @@ public class Name {
     public static final int NAME_CHARACTER_LIMIT = 55;
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Names should only contain english alphanumeric characters and spaces, should not be blank "
+            "Names should only contain english alphanumeric characters or spaces, should not be blank \n"
             + "and must contain less than " + NAME_CHARACTER_LIMIT + " characters";
 
     /*

--- a/src/main/java/seedu/address/model/patient/Phone.java
+++ b/src/main/java/seedu/address/model/patient/Phone.java
@@ -10,7 +10,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Phone {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Only Singaporean phone numbers starting with 6, 8 or 9 are accepted. "
+            "Only Singaporean phone numbers starting with 6, 8 or 9 are accepted. \n"
             + "Phone numbers should only contain numbers, and it should be 8 digits long.";
     public static final String VALIDATION_REGEX = "[689]\\d{7}";
     public final String value;

--- a/src/test/data/JsonUserPrefsStorageTest/ExtraValuesUserPref.json
+++ b/src/test/data/JsonUserPrefsStorageTest/ExtraValuesUserPref.json
@@ -9,5 +9,5 @@
       "z" : 99
     }
   },
-  "addressBookFilePath" : "addressbook.json"
+  "addressBookFilePath" : "CLInic.json"
 }

--- a/src/test/data/JsonUserPrefsStorageTest/TypicalUserPref.json
+++ b/src/test/data/JsonUserPrefsStorageTest/TypicalUserPref.json
@@ -7,5 +7,5 @@
       "y" : 100
     }
   },
-  "addressBookFilePath" : "addressbook.json"
+  "addressBookFilePath" : "CLInic.json"
 }

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -52,7 +52,7 @@ public class LogicManagerTest {
     @BeforeEach
     public void setUp() {
         JsonAddressBookStorage addressBookStorage =
-                new JsonAddressBookStorage(temporaryFolder.resolve("addressBook.json"));
+                new JsonAddressBookStorage(temporaryFolder.resolve("CLInic.json"));
         JsonUserPrefsStorage userPrefsStorage = new JsonUserPrefsStorage(temporaryFolder.resolve("userPrefs.json"));
         StorageManager storage = new StorageManager(addressBookStorage, userPrefsStorage);
         logic = new LogicManager(model, storage);

--- a/src/test/java/seedu/address/storage/JsonUserPrefsStorageTest.java
+++ b/src/test/java/seedu/address/storage/JsonUserPrefsStorageTest.java
@@ -73,7 +73,7 @@ public class JsonUserPrefsStorageTest {
     private UserPrefs getTypicalUserPrefs() {
         UserPrefs userPrefs = new UserPrefs();
         userPrefs.setGuiSettings(new GuiSettings(1000, 500, 300, 100));
-        userPrefs.setAddressBookFilePath(Paths.get("addressbook.json"));
+        userPrefs.setAddressBookFilePath(Paths.get("CLInic.json"));
         return userPrefs;
     }
 


### PR DESCRIPTION
UG states "CLInic.json" while app uses "AddressBook.json".
Refactor "AddressBook.json" to "CLInic.json".

Error messages written by different developers have slight differences.
Improve clarity of error messages thrown for wrong use of commands and standardise the wording.