### PR TITLE
V1.4 fix edit appt

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditApptCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditApptCommand.java
@@ -119,7 +119,8 @@ public class EditApptCommand extends Command {
      * Creates and returns a {@code Appointment} with the details of {@code apptToEdit}
      * edited with {@code editAppointmentDescriptor}.
      */
-    private static Appointment createEditedAppointment(Appointment apptToEdit, EditApptDescriptor editApptDescriptor) {
+    private static Appointment createEditedAppointment(Appointment apptToEdit, EditApptDescriptor editApptDescriptor)
+            throws CommandException {
         assert apptToEdit != null;
 
         Date updatedDate = editApptDescriptor.getDate().orElse(apptToEdit.getDate());
@@ -129,7 +130,11 @@ public class EditApptCommand extends Command {
                 .orElse(apptToEdit.getAppointmentType());
         Note updatedNote = editApptDescriptor.getNote().orElse(apptToEdit.getNote());
 
+        if (!TimePeriod.isValidTimePeriod(updatedStartTime, updatedEndTime)) {
+            throw new CommandException(TimePeriod.MESSAGE_CONSTRAINTS);
+        }
         TimePeriod updatedTimePeriod = new TimePeriod(updatedStartTime, updatedEndTime);
+
 
         return new Appointment(apptToEdit.getNric(), updatedDate, updatedTimePeriod,
                 updatedAppointmentType, updatedNote, apptToEdit.getMark());

--- a/src/main/java/seedu/address/logic/parser/EditApptCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditApptCommandParser.java
@@ -76,6 +76,18 @@ public class EditApptCommandParser implements Parser<EditApptCommand> {
         if (argMultimap.getValue(PREFIX_NEW_END_TIME).isPresent()) {
             editApptDescriptor.setEndTime(ParserUtil.parseTime(argMultimap.getValue(PREFIX_NEW_END_TIME).get()));
         }
+
+        //Check if valid new time period (both new start and end time given)
+        if (argMultimap.getValue(PREFIX_NEW_END_TIME).isPresent() && argMultimap.getValue(PREFIX_NEW_START_TIME).isPresent()) {
+            ParserUtil.parseTimePeriod(argMultimap.getValue(PREFIX_NEW_START_TIME).get(), argMultimap.getValue(PREFIX_NEW_END_TIME).get());
+        }
+
+        //extra check to parse if new end time before current start time (only new end time given)
+        //will check the vice versa in command itself as curr end time not an input
+        if (argMultimap.getValue(PREFIX_NEW_END_TIME).isPresent() && argMultimap.getValue(PREFIX_NEW_START_TIME).isEmpty()) {
+            ParserUtil.parseTimePeriod(argMultimap.getValue(PREFIX_START_TIME).get(), argMultimap.getValue(PREFIX_NEW_END_TIME).get());
+        }
+
         if (argMultimap.getValue(PREFIX_NEW_TAG).isPresent()) {
             editApptDescriptor.setAppointmentType(ParserUtil
                     .parseAppointmentType(argMultimap.getValue(PREFIX_NEW_TAG).get()));

--- a/src/main/java/seedu/address/logic/parser/EditApptCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditApptCommandParser.java
@@ -78,14 +78,18 @@ public class EditApptCommandParser implements Parser<EditApptCommand> {
         }
 
         //Check if valid new time period (both new start and end time given)
-        if (argMultimap.getValue(PREFIX_NEW_END_TIME).isPresent() && argMultimap.getValue(PREFIX_NEW_START_TIME).isPresent()) {
-            ParserUtil.parseTimePeriod(argMultimap.getValue(PREFIX_NEW_START_TIME).get(), argMultimap.getValue(PREFIX_NEW_END_TIME).get());
+        if (argMultimap.getValue(PREFIX_NEW_END_TIME).isPresent()
+                && argMultimap.getValue(PREFIX_NEW_START_TIME).isPresent()) {
+            ParserUtil.parseTimePeriod(argMultimap.getValue(PREFIX_NEW_START_TIME).get(),
+                    argMultimap.getValue(PREFIX_NEW_END_TIME).get());
         }
 
         //extra check to parse if new end time before current start time (only new end time given)
         //will check the vice versa in command itself as curr end time not an input
-        if (argMultimap.getValue(PREFIX_NEW_END_TIME).isPresent() && argMultimap.getValue(PREFIX_NEW_START_TIME).isEmpty()) {
-            ParserUtil.parseTimePeriod(argMultimap.getValue(PREFIX_START_TIME).get(), argMultimap.getValue(PREFIX_NEW_END_TIME).get());
+        if (argMultimap.getValue(PREFIX_NEW_END_TIME).isPresent()
+                && argMultimap.getValue(PREFIX_NEW_START_TIME).isEmpty()) {
+            ParserUtil.parseTimePeriod(argMultimap.getValue(PREFIX_START_TIME).get(),
+                    argMultimap.getValue(PREFIX_NEW_END_TIME).get());
         }
 
         if (argMultimap.getValue(PREFIX_NEW_TAG).isPresent()) {

--- a/src/main/java/seedu/address/logic/parser/EditApptCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditApptCommandParser.java
@@ -77,20 +77,7 @@ public class EditApptCommandParser implements Parser<EditApptCommand> {
             editApptDescriptor.setEndTime(ParserUtil.parseTime(argMultimap.getValue(PREFIX_NEW_END_TIME).get()));
         }
 
-        //Check if valid new time period (both new start and end time given)
-        if (argMultimap.getValue(PREFIX_NEW_END_TIME).isPresent()
-                && argMultimap.getValue(PREFIX_NEW_START_TIME).isPresent()) {
-            ParserUtil.parseTimePeriod(argMultimap.getValue(PREFIX_NEW_START_TIME).get(),
-                    argMultimap.getValue(PREFIX_NEW_END_TIME).get());
-        }
-
-        //extra check to parse if new end time before current start time (only new end time given)
-        //will check the vice versa in command itself as curr end time not an input
-        if (argMultimap.getValue(PREFIX_NEW_END_TIME).isPresent()
-                && argMultimap.getValue(PREFIX_NEW_START_TIME).isEmpty()) {
-            ParserUtil.parseTimePeriod(argMultimap.getValue(PREFIX_START_TIME).get(),
-                    argMultimap.getValue(PREFIX_NEW_END_TIME).get());
-        }
+        //Check if valid new time period (both new start and end time given) in EditAppt Command itself
 
         if (argMultimap.getValue(PREFIX_NEW_TAG).isPresent()) {
             editApptDescriptor.setAppointmentType(ParserUtil

--- a/src/test/java/seedu/address/logic/commands/EditApptCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditApptCommandTest.java
@@ -3,6 +3,7 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_NEW_START_TIME_RANGE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_APPOINTMENT_DATE_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_APPOINTMENT_DATE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_APPOINTMENT_END_TIME_AMY;
@@ -28,6 +29,7 @@ import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.appointment.Appointment;
 import seedu.address.model.appointment.Time;
+import seedu.address.model.appointment.TimePeriod;
 import seedu.address.model.patient.Nric;
 import seedu.address.testutil.AppointmentBuilder;
 import seedu.address.testutil.EditApptDescriptorBuilder;
@@ -114,6 +116,17 @@ public class EditApptCommandTest {
         );
 
         assertCommandFailure(editApptCommand, model, Messages.MESSAGE_APPOINTMENT_NOT_FOUND);
+    }
+
+    @Test
+    public void execute_editedAppointmentInvalidTimePeriod_failure() {
+        //Check when new start time is after or in this case, equals the old end time
+        EditApptDescriptor descriptor = new EditApptDescriptorBuilder()
+                .withStartTime("17:00").build();
+        EditApptCommand editApptCommand = new EditApptCommand(ALICE_APPT.getNric(),
+                ALICE_APPT.getDate(), ALICE_APPT.getStartTime(), descriptor);
+
+        assertCommandFailure(editApptCommand, model, TimePeriod.MESSAGE_CONSTRAINTS);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/EditApptCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditApptCommandTest.java
@@ -3,7 +3,6 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_NEW_START_TIME_RANGE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_APPOINTMENT_DATE_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_APPOINTMENT_DATE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_APPOINTMENT_END_TIME_AMY;

--- a/src/test/java/seedu/address/logic/parser/EditApptCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditApptCommandParserTest.java
@@ -7,9 +7,7 @@ import static seedu.address.logic.commands.CommandTestUtil.INVALID_DATE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NEW_APPOINTMENT_TYPE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NEW_DATE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NEW_END_TIME_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_NEW_END_TIME_RANGE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NEW_START_TIME_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_NEW_START_TIME_RANGE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NRIC_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_START_TIME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.NEW_DATE_DESC_APPOINTMENT_AMY;
@@ -49,7 +47,6 @@ import seedu.address.logic.commands.EditApptCommand;
 import seedu.address.logic.commands.EditApptCommand.EditApptDescriptor;
 import seedu.address.model.appointment.AppointmentType;
 import seedu.address.model.appointment.Time;
-import seedu.address.model.appointment.TimePeriod;
 import seedu.address.model.patient.Nric;
 import seedu.address.testutil.EditApptDescriptorBuilder;
 
@@ -126,13 +123,7 @@ public class EditApptCommandParserTest {
         assertParseFailure(parser, validTargetAppt
                 + INVALID_NEW_END_TIME_DESC , Time.MESSAGE_CONSTRAINTS); // invalid new endTime (itself)
 
-        //invalid new start time is checked in EditApptCommand instead
-
-        assertParseFailure(parser, validTargetAppt
-                + INVALID_NEW_END_TIME_RANGE_DESC, TimePeriod.MESSAGE_CONSTRAINTS); //invalid new end time
-        assertParseFailure(parser, validTargetAppt
-                + INVALID_NEW_START_TIME_RANGE_DESC
-                + INVALID_NEW_END_TIME_RANGE_DESC, TimePeriod.MESSAGE_CONSTRAINTS); //invalid new start, end time period
+        //invalid new start time and invalid new end time is checked in EditApptCommand instead
         assertParseFailure(parser, validTargetAppt
                 + INVALID_NEW_APPOINTMENT_TYPE_DESC , AppointmentType.MESSAGE_CONSTRAINTS); // invalid new apptType
 

--- a/src/test/java/seedu/address/logic/parser/EditApptCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditApptCommandParserTest.java
@@ -132,7 +132,7 @@ public class EditApptCommandParserTest {
                 + INVALID_NEW_END_TIME_RANGE_DESC, TimePeriod.MESSAGE_CONSTRAINTS); //invalid new end time
         assertParseFailure(parser, validTargetAppt
                 + INVALID_NEW_START_TIME_RANGE_DESC
-                + INVALID_NEW_END_TIME_RANGE_DESC, TimePeriod.MESSAGE_CONSTRAINTS); //invalid new start and end time period
+                + INVALID_NEW_END_TIME_RANGE_DESC, TimePeriod.MESSAGE_CONSTRAINTS); //invalid new start, end time period
         assertParseFailure(parser, validTargetAppt
                 + INVALID_NEW_APPOINTMENT_TYPE_DESC , AppointmentType.MESSAGE_CONSTRAINTS); // invalid new apptType
 

--- a/src/test/java/seedu/address/logic/parser/EditApptCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditApptCommandParserTest.java
@@ -7,7 +7,9 @@ import static seedu.address.logic.commands.CommandTestUtil.INVALID_DATE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NEW_APPOINTMENT_TYPE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NEW_DATE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NEW_END_TIME_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_NEW_END_TIME_RANGE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NEW_START_TIME_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_NEW_START_TIME_RANGE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NRIC_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_START_TIME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.NEW_DATE_DESC_APPOINTMENT_AMY;
@@ -47,6 +49,7 @@ import seedu.address.logic.commands.EditApptCommand;
 import seedu.address.logic.commands.EditApptCommand.EditApptDescriptor;
 import seedu.address.model.appointment.AppointmentType;
 import seedu.address.model.appointment.Time;
+import seedu.address.model.appointment.TimePeriod;
 import seedu.address.model.patient.Nric;
 import seedu.address.testutil.EditApptDescriptorBuilder;
 
@@ -119,9 +122,17 @@ public class EditApptCommandParserTest {
         assertParseFailure(parser, validTargetAppt
                 + INVALID_NEW_DATE_DESC , Date.MESSAGE_CONSTRAINTS); // invalid new date
         assertParseFailure(parser, validTargetAppt
-                + INVALID_NEW_START_TIME_DESC , Time.MESSAGE_CONSTRAINTS); // invalid new startTime
+                + INVALID_NEW_START_TIME_DESC , Time.MESSAGE_CONSTRAINTS); // invalid new startTime (itself)
         assertParseFailure(parser, validTargetAppt
-                + INVALID_NEW_END_TIME_DESC , Time.MESSAGE_CONSTRAINTS); // invalid new endTime
+                + INVALID_NEW_END_TIME_DESC , Time.MESSAGE_CONSTRAINTS); // invalid new endTime (itself)
+
+        //invalid new start time is checked in EditApptCommand instead
+
+        assertParseFailure(parser, validTargetAppt
+                + INVALID_NEW_END_TIME_RANGE_DESC, TimePeriod.MESSAGE_CONSTRAINTS); //invalid new end time
+        assertParseFailure(parser, validTargetAppt
+                + INVALID_NEW_START_TIME_RANGE_DESC
+                + INVALID_NEW_END_TIME_RANGE_DESC, TimePeriod.MESSAGE_CONSTRAINTS); //invalid new start and end time period
         assertParseFailure(parser, validTargetAppt
                 + INVALID_NEW_APPOINTMENT_TYPE_DESC , AppointmentType.MESSAGE_CONSTRAINTS); // invalid new apptType
 


### PR DESCRIPTION
Fixed the bug to check for:
- when user edits new endtime to be before/= curr start time, error
- when user edits new starttime to be after/= curr endtime, error 
- when user tries new start and endtime that is an invalid timePeriod, error

Added tests for these checks.