### PR TITLE
Bug fix to allow EditApptCommand to validate that appointment date is not before DOB

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditApptCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditApptCommand.java
@@ -64,6 +64,8 @@ public class EditApptCommand extends Command {
                     + "Please refer to the Overall-View for the list of appointments "
                     + "for that patient on the same date.";
 
+    public static final String MESSAGE_EDIT_APPOINTMENT_BEFORE_DOB_FAILURE =
+            "The appointment date for the edited appointment is before the date of birth of the given patient.";
     private final Nric targetNric;
     private final Date targetDate;
     private final Time targetStartTime;
@@ -108,6 +110,11 @@ public class EditApptCommand extends Command {
         // Must check for overlapping appointments of new appt besides current appt
         if (model.hasOverlappingAppointmentExcluding(apptToEdit, editedAppt)) {
             throw new CommandException(MESSAGE_EDIT_OVERLAPPING_APPOINTMENT_FAILURE);
+        }
+
+        // Must check if appointment date is before DOB
+        if (!model.isValidApptForPatient(editedAppt)) {
+            throw new CommandException(MESSAGE_EDIT_APPOINTMENT_BEFORE_DOB_FAILURE);
         }
 
         model.setAppointment(apptToEdit, editedAppt);

--- a/src/test/java/seedu/address/logic/commands/EditApptCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditApptCommandTest.java
@@ -151,6 +151,16 @@ public class EditApptCommandTest {
     }
 
     @Test
+    public void execute_editedAppointmentDateBeforeDob_throwsCommandException() {
+        EditApptDescriptor descriptor = new EditApptDescriptorBuilder()
+                .withDate("1900-01-02").build();
+        EditApptCommand editApptCommand = new EditApptCommand(ALICE_APPT.getNric(),
+                ALICE_APPT.getDate(), ALICE_APPT.getStartTime(), descriptor);
+
+        assertCommandFailure(editApptCommand, model, EditApptCommand.MESSAGE_EDIT_APPOINTMENT_BEFORE_DOB_FAILURE);
+    }
+
+    @Test
     public void equals() {
         final EditApptDescriptor descriptor = new EditApptDescriptorBuilder()
                 .withDate(VALID_APPOINTMENT_DATE_BOB).build();


### PR DESCRIPTION
`EditApptCommand` did not check if new appointment date is before DOB.

This could cause database to be corrupted and a failed initialisation after.

Add existing checks built for `AddApptCommand` to `EditApptCommand`

Closes #180 